### PR TITLE
Upgrade tooltester to Java 17 and Dockstore 1.13.1

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Cache
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v3
         with:
           # A list of files, directories, and wildcard patterns to cache and restore
           path: ~/.m2/repository
@@ -34,9 +34,9 @@ jobs:
           docker run -d --net travisnet --ip 172.18.0.22 quay.io/garyluu/jenkins
           # Sleep for 20 seconds while jenkins loads
           sleep 20
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 17
       - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,10 +35,10 @@ jobs:
           # Sleep for 20 seconds while jenkins loads
           sleep 20
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Build with Maven
         run: cd tooltester && mvn -B clean install -DskipITs=false
       - name: code coverage

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: 'adopt'
       - name: Build with Maven
         run: cd tooltester && mvn -B clean install -DskipITs=false
       - name: code coverage

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Cache

--- a/tooltester/pom.xml
+++ b/tooltester/pom.xml
@@ -271,8 +271,8 @@
             <version>1.13.1</version>
             <exclusions>
                 <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -300,6 +300,16 @@
             <groupId>com.offbytwo.jenkins</groupId>
             <artifactId>jenkins-client</artifactId>
             <version>0.3.8</version>
+            <exclusions>
+                <exclusion>  <!-- declare the exclusion here -->
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>  <!-- declare the exclusion here -->
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/tooltester/pom.xml
+++ b/tooltester/pom.xml
@@ -261,6 +261,11 @@
             <version>2.37</version>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>2.37</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.9.0</version>
@@ -647,6 +652,9 @@
                             <failOnWarning>true</failOnWarning>
                             <outputXML>true</outputXML>
                             <ignoreNonCompile>true</ignoreNonCompile>
+                            <usedDependencies>
+                                <usedDependency>org.glassfish.jersey.inject:jersey-hk2</usedDependency>
+                            </usedDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/tooltester/pom.xml
+++ b/tooltester/pom.xml
@@ -36,10 +36,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.url>scm:git:git@github.com:dockstore/dockstore-support.git</github.url>
-        <assertj.version>3.4.1</assertj.version>
         <junit-version>4.13.2</junit-version>
         <slf4j.version>1.7.36</slf4j.version>
-        <cwlavro.version>2.0.4.7</cwlavro.version>
         <jackson.version>2.13.4</jackson.version>
         <aws.version>1.11.86</aws.version>
     </properties>

--- a/tooltester/pom.xml
+++ b/tooltester/pom.xml
@@ -40,6 +40,7 @@
         <slf4j.version>1.7.36</slf4j.version>
         <jackson.version>2.13.4</jackson.version>
         <aws.version>1.11.86</aws.version>
+        <dockstore.core.version>1.13.1</dockstore.core.version>
     </properties>
 
     <organization>
@@ -117,7 +118,7 @@
                 <groupId>io.dockstore</groupId>
                 <artifactId>bom-internal</artifactId>
                 <type>pom</type>
-                <version>1.13.1</version>
+                <version>${dockstore.core.version}</version>
                 <scope>import</scope>
             </dependency>
             <!--  cwl management -->
@@ -268,7 +269,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.13.1</version>
+            <version>${dockstore.core.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>jakarta.activation</groupId>

--- a/tooltester/pom.xml
+++ b/tooltester/pom.xml
@@ -299,19 +299,19 @@
             <artifactId>jenkins-client</artifactId>
             <version>0.3.8</version>
             <exclusions>
-                <exclusion>  <!-- declare the exclusion here -->
+                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
-                <exclusion>  <!-- declare the exclusion here -->
+                <exclusion>
                     <groupId>commons-lang</groupId>
                     <artifactId>commons-lang</artifactId>
                 </exclusion>
-                <exclusion>  <!-- declare the exclusion here -->
+                <exclusion>
                     <groupId>commons-collections</groupId>
                     <artifactId>commons-collections</artifactId>
                 </exclusion>
-                <exclusion>  <!-- declare the exclusion here -->
+                <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient</artifactId>
                 </exclusion>

--- a/tooltester/pom.xml
+++ b/tooltester/pom.xml
@@ -115,11 +115,17 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>io.dockstore</groupId>
+                <artifactId>bom-internal</artifactId>
+                <type>pom</type>
+                <version>1.13.1</version>
+                <scope>import</scope>
+            </dependency>
             <!--  cwl management -->
             <dependency>
                 <groupId>io.cwl</groupId>
                 <artifactId>cwlavro-tools</artifactId>
-                <version>${cwlavro.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.httpcomponents</groupId>
@@ -139,7 +145,6 @@
             <dependency>
                 <groupId>io.cwl</groupId>
                 <artifactId>cwlavro-generated</artifactId>
-                <version>${cwlavro.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.httpcomponents</groupId>
@@ -154,7 +159,6 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -194,29 +198,26 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.11.0</version>
             </dependency>
 
             <!-- Dependency convergence error-->
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>4.4.15</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.13</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
                 <version>1.2</version>
+<!--                Can't remove this or get error?-->
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-core</artifactId>
-                <version>1.3</version>
             </dependency>
         </dependencies>
 
@@ -258,7 +259,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>2.37</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>
@@ -268,7 +268,6 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.9.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -302,7 +301,6 @@
             <version>1.10</version>
         </dependency>
         <dependency>
-<!--            CHECK-->
             <groupId>com.offbytwo.jenkins</groupId>
             <artifactId>jenkins-client</artifactId>
             <version>0.3.8</version>
@@ -314,6 +312,22 @@
                 <exclusion>  <!-- declare the exclusion here -->
                     <groupId>commons-lang</groupId>
                     <artifactId>commons-lang</artifactId>
+                </exclusion>
+                <exclusion>  <!-- declare the exclusion here -->
+                    <groupId>commons-collections</groupId>
+                    <artifactId>commons-collections</artifactId>
+                </exclusion>
+                <exclusion>  <!-- declare the exclusion here -->
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -328,7 +342,6 @@
 
         </dependency>
         <dependency>
-<!--            CHECK, likely good-->
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <version>1.3</version>
@@ -345,7 +358,6 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.78</version>
         </dependency>
 
         <!-- For AWS integration START -->

--- a/tooltester/pom.xml
+++ b/tooltester/pom.xml
@@ -38,9 +38,9 @@
         <github.url>scm:git:git@github.com:dockstore/dockstore-support.git</github.url>
         <assertj.version>3.4.1</assertj.version>
         <junit-version>4.11</junit-version>
-        <slf4j.version>1.7.21</slf4j.version>
-        <cwlavro.version>1.0.6</cwlavro.version>
-        <jackson.version>2.12.2</jackson.version>
+        <slf4j.version>1.7.36</slf4j.version>
+        <cwlavro.version>2.0.4.7</cwlavro.version>
+        <jackson.version>2.13.4</jackson.version>
         <aws.version>1.11.86</aws.version>
     </properties>
 
@@ -152,9 +152,9 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>2.6</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.12.0</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -172,6 +172,7 @@
                 <version>${jackson.version}</version>
             </dependency>
 
+<!--            CHECK-->
             <dependency>
                 <groupId>xml-apis</groupId>
                 <artifactId>xml-apis</artifactId>
@@ -192,19 +193,19 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.7</version>
+                <version>2.11.0</version>
             </dependency>
 
             <!-- Dependency convergence error-->
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>4.4.4</version>
+                <version>4.4.15</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.2</version>
+                <version>4.5.13</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>
@@ -232,6 +233,7 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+<!--            CHECK-->
             <groupId>de.vandermeer</groupId>
             <artifactId>asciitable</artifactId>
             <version>0.2.5</version>
@@ -239,7 +241,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.11.0</version>
         </dependency>
         <!--<dependency>-->
             <!--<groupId>com.github.docker-java</groupId>-->
@@ -247,6 +249,7 @@
             <!--<version>3.0.6</version>-->
         <!--</dependency>-->
         <dependency>
+<!--            CHECK-->
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
             <version>2.0.1</version>
@@ -254,18 +257,18 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>2.25.1</version>
+            <version>2.37</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.9.0</version>
+            <version>1.13.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>
@@ -285,12 +288,15 @@
             <version>${slf4j.version}</version>
             <scope>runtime</scope>
         </dependency>
+
         <dependency>
+<!--            CHECK-->
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
             <version>1.10</version>
         </dependency>
         <dependency>
+<!--            CHECK-->
             <groupId>com.offbytwo.jenkins</groupId>
             <artifactId>jenkins-client</artifactId>
             <version>0.3.8</version>
@@ -298,6 +304,7 @@
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>
+<!--            CHECK-->
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
@@ -305,6 +312,7 @@
 
         </dependency>
         <dependency>
+<!--            CHECK, likely good-->
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <version>1.3</version>
@@ -321,28 +329,32 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.60</version>
+            <version>1.78</version>
         </dependency>
 
         <!-- For AWS integration START -->
         <dependency>
+<!--            CHECK-->
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
             <version>${aws.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
+<!--            CHECK-->
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
             <version>${aws.version}</version>
         </dependency>
         <dependency>
+<!--            CHECK-->
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
             <version>1.1.1</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
+<!--            CHECK-->
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.2.11</version>

--- a/tooltester/pom.xml
+++ b/tooltester/pom.xml
@@ -175,7 +175,6 @@
                 <version>${jackson.version}</version>
             </dependency>
 
-<!--            CHECK-->
             <dependency>
                 <groupId>xml-apis</groupId>
                 <artifactId>xml-apis</artifactId>
@@ -233,7 +232,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-<!--            CHECK-->
             <groupId>de.vandermeer</groupId>
             <artifactId>asciitable</artifactId>
             <version>0.2.5</version>
@@ -249,7 +247,6 @@
             <!--<version>3.0.6</version>-->
         <!--</dependency>-->
         <dependency>
-<!--            CHECK-->
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
             <version>2.0.1</version>
@@ -293,7 +290,6 @@
         </dependency>
 
         <dependency>
-<!--            CHECK-->
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
             <version>1.10</version>
@@ -332,7 +328,6 @@
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>
-<!--            CHECK-->
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
@@ -360,27 +355,23 @@
 
         <!-- For AWS integration START -->
         <dependency>
-<!--            CHECK-->
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
             <version>${aws.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
-<!--            CHECK-->
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
             <version>${aws.version}</version>
         </dependency>
         <dependency>
-<!--            CHECK-->
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
             <version>1.1.1</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
-<!--            CHECK-->
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.2.11</version>

--- a/tooltester/pom.xml
+++ b/tooltester/pom.xml
@@ -37,7 +37,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.url>scm:git:git@github.com:dockstore/dockstore-support.git</github.url>
         <assertj.version>3.4.1</assertj.version>
-        <junit-version>4.11</junit-version>
+        <junit-version>4.13.2</junit-version>
         <slf4j.version>1.7.36</slf4j.version>
         <cwlavro.version>2.0.4.7</cwlavro.version>
         <jackson.version>2.13.4</jackson.version>
@@ -557,7 +557,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.7</version>
                 <executions>
                     <execution>
                         <goals>

--- a/tooltester/pom.xml
+++ b/tooltester/pom.xml
@@ -164,6 +164,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
+                <scope>test</scope>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
@@ -390,9 +391,9 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.10.1</version>
                     <configuration>
-                        <release>11</release>
+                        <release>17</release>
                         <showDeprecation>true</showDeprecation>
                     </configuration>
                 </plugin>
@@ -419,15 +420,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.1</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.shared</groupId>
-                            <artifactId>maven-dependency-analyzer</artifactId>
-                            <version>1.11.1</version>
-                        </dependency>
-                    </dependencies>
-
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -662,7 +655,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <release>11</release>
+                    <release>17</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/tooltester/src/main/java/io/dockstore/tooltester/client/cli/Client.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/client/cli/Client.java
@@ -319,7 +319,7 @@ public class Client {
 
     @SuppressWarnings("checkstyle:parameternumber")
     private Map<String, String> constructParameterMap(String url, String referenceName, String entryType, String dockerfilePath,
-                                                      String parameterPath, String descriptorPath, String synapseCache, String runner, String commands) {
+            String parameterPath, String descriptorPath, String synapseCache, String runner, String commands) {
         Map<String, String> parameter = new HashMap<>();
         parameter.put("URL", url);
         parameter.put("ParameterPath", parameterPath);

--- a/tooltester/src/main/java/io/dockstore/tooltester/client/cli/Client.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/client/cli/Client.java
@@ -64,6 +64,7 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.dockstore.tooltester.client.cli.JCommanderUtility.out;
 import static io.dockstore.tooltester.client.cli.JCommanderUtility.printJCommanderHelp;
 import static io.dockstore.tooltester.helper.ExceptionHandler.API_ERROR;
 import static io.dockstore.tooltester.helper.ExceptionHandler.COMMAND_ERROR;
@@ -107,51 +108,64 @@ public class Client {
         jc.addCommand("enqueue", commandEnqueue);
         jc.addCommand("file-report", commandFileReport);
         jc.addCommand("sync", commandSync);
+        System.out.println("A");
         try {
+            System.out.println("A");
             jc.parse(argv);
+            System.out.println("C");
         } catch (MissingCommandException e) {
             jc.usage();
-            exceptionMessage(e, "Unknown command", COMMAND_ERROR);
+            if (e.getUnknownCommand().isEmpty()) {
+                out("No command entered");
+                return;
+            } else {
+                exceptionMessage(e, "Unknown command", COMMAND_ERROR);
+            }
         }
         if (commandMain.help) {
+            System.out.println("F");
             jc.usage();
         } else {
-
-            if (jc.getParsedCommand() != null) {
-                switch (jc.getParsedCommand()) {
-                    case "report":
-                        if (commandReport.help) {
-                            printJCommanderHelp(jc, "autotool", "report");
-                        } else {
-                            client.handleReport(commandReport.tools, commandEnqueue.source);
-                        }
-                        break;
-                    case "enqueue":
-                        if (commandEnqueue.help) {
-                            printJCommanderHelp(jc, "autotool", "enqueue");
-                        } else {
-                            client.handleRunTests(commandEnqueue.tools, commandEnqueue.source);
-                        }
-                        break;
-                    case "file-report":
-                        if (commandFileReport.help) {
-                            printJCommanderHelp(jc, "autotool", "file-report");
-                        } else {
-                            client.handleFileReport(commandFileReport.tool);
-                        }
-                        break;
-                    case "sync":
-                        if (commandSync.help) {
-                            printJCommanderHelp(jc, "autotool", "sync");
-                        } else {
-                            client.handleCreateTests(commandSync.tools, commandSync.source);
-                        }
-                        break;
-                    default:
-                        jc.usage();
-                }
-            } else {
-                jc.usage();
+            switch (jc.getParsedCommand()) {
+                case "report":
+                    if (commandReport.help) {
+                        System.out.println("G");
+                        printJCommanderHelp(jc, "autotool", "report");
+                    } else {
+                        System.out.println("H");
+                        client.handleReport(commandReport.tools, commandEnqueue.source);
+                    }
+                    break;
+                case "enqueue":
+                    if (commandEnqueue.help) {
+                        System.out.println("I");
+                        printJCommanderHelp(jc, "autotool", "enqueue");
+                    } else {
+                        System.out.println("J");
+                        client.handleRunTests(commandEnqueue.tools, commandEnqueue.source);
+                    }
+                    break;
+                case "file-report":
+                    if (commandFileReport.help) {
+                        System.out.println("K");
+                        printJCommanderHelp(jc, "autotool", "file-report");
+                    } else {
+                        System.out.println("L");
+                        client.handleFileReport(commandFileReport.tool);
+                    }
+                    break;
+                case "sync":
+                    if (commandSync.help) {
+                        System.out.println("M");
+                        printJCommanderHelp(jc, "autotool", "sync");
+                    } else {
+                        System.out.println("N");
+                        client.handleCreateTests(commandSync.tools, commandSync.source);
+                    }
+                    break;
+                default:
+                    System.out.println("O");
+                    jc.usage();
             }
         }
     }

--- a/tooltester/src/main/java/io/dockstore/tooltester/client/cli/Client.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/client/cli/Client.java
@@ -108,11 +108,8 @@ public class Client {
         jc.addCommand("enqueue", commandEnqueue);
         jc.addCommand("file-report", commandFileReport);
         jc.addCommand("sync", commandSync);
-        System.out.println("A");
         try {
-            System.out.println("A");
             jc.parse(argv);
-            System.out.println("C");
         } catch (MissingCommandException e) {
             jc.usage();
             if (e.getUnknownCommand().isEmpty()) {
@@ -123,49 +120,41 @@ public class Client {
             }
         }
         if (commandMain.help) {
-            System.out.println("F");
             jc.usage();
         } else {
             switch (jc.getParsedCommand()) {
                 case "report":
                     if (commandReport.help) {
-                        System.out.println("G");
                         printJCommanderHelp(jc, "autotool", "report");
                     } else {
-                        System.out.println("H");
                         client.handleReport(commandReport.tools, commandEnqueue.source);
                     }
                     break;
                 case "enqueue":
                     if (commandEnqueue.help) {
-                        System.out.println("I");
                         printJCommanderHelp(jc, "autotool", "enqueue");
                     } else {
-                        System.out.println("J");
                         client.handleRunTests(commandEnqueue.tools, commandEnqueue.source);
                     }
                     break;
                 case "file-report":
                     if (commandFileReport.help) {
-                        System.out.println("K");
                         printJCommanderHelp(jc, "autotool", "file-report");
                     } else {
-                        System.out.println("L");
                         client.handleFileReport(commandFileReport.tool);
                     }
                     break;
                 case "sync":
                     if (commandSync.help) {
-                        System.out.println("M");
                         printJCommanderHelp(jc, "autotool", "sync");
                     } else {
-                        System.out.println("N");
                         client.handleCreateTests(commandSync.tools, commandSync.source);
                     }
                     break;
                 default:
-                    System.out.println("O");
                     jc.usage();
+                    // This line should never get called, as this case would've been caught when
+                    // jc.parse(argv) was called
             }
         }
     }

--- a/tooltester/src/main/java/io/dockstore/tooltester/client/cli/Client.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/client/cli/Client.java
@@ -121,6 +121,9 @@ public class Client {
         }
         if (commandMain.help) {
             jc.usage();
+
+        } else if (jc.getParsedCommand() == null) {
+            jc.usage();
         } else {
             switch (jc.getParsedCommand()) {
                 case "report":

--- a/tooltester/src/main/java/io/dockstore/tooltester/client/cli/Client.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/client/cli/Client.java
@@ -115,33 +115,36 @@ public class Client {
         if (commandMain.help) {
             jc.usage();
         } else {
-
             if (jc.getParsedCommand() != null) {
                 switch (jc.getParsedCommand()) {
                 case "report":
                     if (commandReport.help) {
-                        jc.usage("report");
+//                        jc.usage("report");
+                        System.out.println("D");
                     } else {
                         client.handleReport(commandReport.tools, commandEnqueue.source);
                     }
                     break;
                 case "enqueue":
                     if (commandEnqueue.help) {
-                        jc.usage("enqueue");
+//                        jc.usage("enqueue");
+                        System.out.println("A");
                     } else {
                         client.handleRunTests(commandEnqueue.tools, commandEnqueue.source);
                     }
                     break;
                 case "file-report":
                     if (commandFileReport.help) {
-                        jc.usage("file-report");
+//                        jc.usage("file-report");
+                        System.out.println("B");
                     } else {
                         client.handleFileReport(commandFileReport.tool);
                     }
                     break;
                 case "sync":
                     if (commandSync.help) {
-                        jc.usage("sync");
+//                        jc.usage("sync");
+                        System.out.println("C");
                     } else {
                         client.handleCreateTests(commandSync.tools, commandSync.source);
                     }

--- a/tooltester/src/main/java/io/dockstore/tooltester/client/cli/Client.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/client/cli/Client.java
@@ -64,6 +64,7 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.dockstore.tooltester.client.cli.JCommanderUtility.printJCommanderHelp;
 import static io.dockstore.tooltester.helper.ExceptionHandler.API_ERROR;
 import static io.dockstore.tooltester.helper.ExceptionHandler.COMMAND_ERROR;
 import static io.dockstore.tooltester.helper.ExceptionHandler.DEBUG;
@@ -115,42 +116,39 @@ public class Client {
         if (commandMain.help) {
             jc.usage();
         } else {
+
             if (jc.getParsedCommand() != null) {
                 switch (jc.getParsedCommand()) {
-                case "report":
-                    if (commandReport.help) {
-//                        jc.usage("report");
-                        System.out.println("D");
-                    } else {
-                        client.handleReport(commandReport.tools, commandEnqueue.source);
-                    }
-                    break;
-                case "enqueue":
-                    if (commandEnqueue.help) {
-//                        jc.usage("enqueue");
-                        System.out.println("A");
-                    } else {
-                        client.handleRunTests(commandEnqueue.tools, commandEnqueue.source);
-                    }
-                    break;
-                case "file-report":
-                    if (commandFileReport.help) {
-//                        jc.usage("file-report");
-                        System.out.println("B");
-                    } else {
-                        client.handleFileReport(commandFileReport.tool);
-                    }
-                    break;
-                case "sync":
-                    if (commandSync.help) {
-//                        jc.usage("sync");
-                        System.out.println("C");
-                    } else {
-                        client.handleCreateTests(commandSync.tools, commandSync.source);
-                    }
-                    break;
-                default:
-                    jc.usage();
+                    case "report":
+                        if (commandReport.help) {
+                            printJCommanderHelp(jc, "autotool", "report");
+                        } else {
+                            client.handleReport(commandReport.tools, commandEnqueue.source);
+                        }
+                        break;
+                    case "enqueue":
+                        if (commandEnqueue.help) {
+                            printJCommanderHelp(jc, "autotool", "enqueue");
+                        } else {
+                            client.handleRunTests(commandEnqueue.tools, commandEnqueue.source);
+                        }
+                        break;
+                    case "file-report":
+                        if (commandFileReport.help) {
+                            printJCommanderHelp(jc, "autotool", "file-report");
+                        } else {
+                            client.handleFileReport(commandFileReport.tool);
+                        }
+                        break;
+                    case "sync":
+                        if (commandSync.help) {
+                            printJCommanderHelp(jc, "autotool", "sync");
+                        } else {
+                            client.handleCreateTests(commandSync.tools, commandSync.source);
+                        }
+                        break;
+                    default:
+                        jc.usage();
                 }
             } else {
                 jc.usage();
@@ -318,7 +316,7 @@ public class Client {
 
     @SuppressWarnings("checkstyle:parameternumber")
     private Map<String, String> constructParameterMap(String url, String referenceName, String entryType, String dockerfilePath,
-            String parameterPath, String descriptorPath, String synapseCache, String runner, String commands) {
+                                                      String parameterPath, String descriptorPath, String synapseCache, String runner, String commands) {
         Map<String, String> parameter = new HashMap<>();
         parameter.put("URL", url);
         parameter.put("ParameterPath", parameterPath);
@@ -444,15 +442,15 @@ public class Client {
                 return false;
             } else {
                 switch (name) {
-                case "CommandLineTool":
-                    testDockstoreTool(tool);
-                    break;
-                case "Workflow":
-                    testWorkflow(tool);
-                    break;
-                default:
-                    LOG.error("Unrecognized toolclass name.  Expected 'CommandLineTool' or 'Workflow'.  Got " + name);
-                    return false;
+                    case "CommandLineTool":
+                        testDockstoreTool(tool);
+                        break;
+                    case "Workflow":
+                        testWorkflow(tool);
+                        break;
+                    default:
+                        LOG.error("Unrecognized toolclass name.  Expected 'CommandLineTool' or 'Workflow'.  Got " + name);
+                        return false;
                 }
             }
         }

--- a/tooltester/src/main/java/io/dockstore/tooltester/client/cli/Client.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/client/cli/Client.java
@@ -445,15 +445,15 @@ public class Client {
                 return false;
             } else {
                 switch (name) {
-                    case "CommandLineTool":
-                        testDockstoreTool(tool);
-                        break;
-                    case "Workflow":
-                        testWorkflow(tool);
-                        break;
-                    default:
-                        LOG.error("Unrecognized toolclass name.  Expected 'CommandLineTool' or 'Workflow'.  Got " + name);
-                        return false;
+                case "CommandLineTool":
+                    testDockstoreTool(tool);
+                    break;
+                case "Workflow":
+                    testWorkflow(tool);
+                    break;
+                default:
+                    LOG.error("Unrecognized toolclass name.  Expected 'CommandLineTool' or 'Workflow'.  Got " + name);
+                    return false;
                 }
             }
         }

--- a/tooltester/src/main/java/io/dockstore/tooltester/client/cli/JCommanderUtility.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/client/cli/JCommanderUtility.java
@@ -60,11 +60,7 @@ public final class JCommanderUtility {
 
     private static void printJCommanderHelpUsage(String programName, String commandName, JCommander jc) {
         out("Usage: " + programName + " " + commandName + " --help");
-        if (jc.getCommands().isEmpty()) {
-            out("       " + programName + " " + commandName + " [parameters]");
-        } else {
-            out("       " + programName + " " + commandName + " [parameters] [command]");
-        }
+        out("       " + programName + " " + commandName + " [parameters] [command]");
         out("");
     }
 
@@ -134,9 +130,6 @@ public final class JCommanderUtility {
     private static void printJCommanderHelpParameter(ParameterDescription pd, WrappedParameter parameter, int maxLength) {
         outFormatted("%-" + maxLength + "s %s", "  " + pd.getNames() + " <" + pd.getNames().replaceAll("--", "") + ">", pd.getDescription());
         Object def = pd.getDefault();
-        if (pd.isDynamicParameter()) {
-            out("Syntax: " + parameter.names()[0] + "key" + parameter.getAssignment() + "value");
-        }
         if (def != null && !pd.isHelp()) {
             String displayedDef = Strings.isStringEmpty(def.toString()) ? "<empty string>" : def.toString();
             outFormatted("%-" + maxLength + "s %s", "  ", "Default: " + (parameter.password() ? "********" : displayedDef));

--- a/tooltester/src/main/java/io/dockstore/tooltester/client/cli/JCommanderUtility.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/client/cli/JCommanderUtility.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2017 OICR
+ *    Copyright 2023 OICR
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/tooltester/src/main/java/io/dockstore/tooltester/client/cli/JCommanderUtility.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/client/cli/JCommanderUtility.java
@@ -1,0 +1,146 @@
+/*
+ *    Copyright 2017 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.dockstore.tooltester.client.cli;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.beust.jcommander.DefaultUsageFormatter;
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterDescription;
+import com.beust.jcommander.Strings;
+import com.beust.jcommander.WrappedParameter;
+
+
+/**
+ * This is very similar to
+ * https://github.com/dockstore/dockstore-cli/blob/ca3c73f8884ec2a9cc5b25e6a3b26594df1752f1/dockstore-client/src/main/java/io/dockstore/client/cli/JCommanderUtility.java
+ */
+public final class JCommanderUtility {
+    private JCommanderUtility() {
+        // hide the constructor for utility classes
+    }
+
+    public static void out(String arg) {
+        System.out.println(arg);
+    }
+
+    public static void outFormatted(String format, Object... args) {
+        System.out.println(String.format(format, args));
+    }
+
+
+    public static void printJCommanderHelp(JCommander jc, String programName, String commandName) {
+        JCommander commander = jc.getCommands().get(commandName);
+        DefaultUsageFormatter formatter = new DefaultUsageFormatter(jc);
+        String description = formatter.getCommandDescription(commandName);
+        List<ParameterDescription> sorted = commander.getParameters();
+
+        printJCommanderHelpUsage(programName, commandName, commander);
+        printJCommanderHelpDescription(description);
+        printJCommanderHelpCommand(commander);
+        printJCommanderHelpRequiredParameters(sorted);
+        printJCommanderHelpOptionalParameters(sorted);
+    }
+
+    private static void printJCommanderHelpUsage(String programName, String commandName, JCommander jc) {
+        out("Usage: " + programName + " " + commandName + " --help");
+        if (jc.getCommands().isEmpty()) {
+            out("       " + programName + " " + commandName + " [parameters]");
+        } else {
+            out("       " + programName + " " + commandName + " [parameters] [command]");
+        }
+        out("");
+    }
+
+    private static void printJCommanderHelpCommand(JCommander jc) {
+        DefaultUsageFormatter formatter = new DefaultUsageFormatter(jc);
+        Map<String, JCommander> commands = jc.getCommands();
+        if (!commands.isEmpty()) {
+            out("Commands: ");
+            for (Map.Entry<String, JCommander> commanderEntry : commands.entrySet()) {
+                out("  " + commanderEntry.getKey());
+                out("    " + formatter.getCommandDescription(commanderEntry.getKey()));
+            }
+        }
+    }
+
+    private static void printJCommanderHelpDescription(String commandDescription) {
+        out("Description:");
+        out("  " + commandDescription);
+        out("");
+    }
+
+    private static void printJCommanderHelpRequiredParameters(List<ParameterDescription> sorted) {
+        int maxLength = 0;
+        for (ParameterDescription pd : sorted) {
+            int length = pd.getNames().length();
+            maxLength = Math.max(length, maxLength);
+        }
+        maxLength = ((maxLength + 2) * 2);
+        boolean first = true;
+        for (ParameterDescription pd : sorted) {
+            WrappedParameter parameter = pd.getParameter();
+            if (parameter.required() && !Objects.equals(pd.getNames(), "--help")) {
+                if (first) {
+                    out("Required parameters:");
+                    first = false;
+                }
+                printJCommanderHelpParameter(pd, parameter, maxLength);
+            }
+        }
+        out("");
+    }
+
+    private static void printJCommanderHelpOptionalParameters(List<ParameterDescription> sorted) {
+        int maxLength;
+        ParameterDescription maxParameter = Collections.max(sorted, (first, second) -> {
+            if (first.getNames().length() > second.getNames().length()) {
+                return 1;
+            } else {
+                return 0;
+            }
+        });
+        maxLength = ((maxParameter.getNames().length() + 2) * 2);
+        boolean first = true;
+        for (ParameterDescription pd : sorted) {
+            WrappedParameter parameter = pd.getParameter();
+            if (!parameter.required() && !pd.getNames().equals("--help")) {
+                if (first) {
+                    out("Optional parameters:");
+                    first = false;
+                }
+                printJCommanderHelpParameter(pd, parameter, maxLength);
+            }
+        }
+        out("");
+    }
+
+    private static void printJCommanderHelpParameter(ParameterDescription pd, WrappedParameter parameter, int maxLength) {
+        outFormatted("%-" + maxLength + "s %s", "  " + pd.getNames() + " <" + pd.getNames().replaceAll("--", "") + ">", pd.getDescription());
+        Object def = pd.getDefault();
+        if (pd.isDynamicParameter()) {
+            out("Syntax: " + parameter.names()[0] + "key" + parameter.getAssignment() + "value");
+        }
+        if (def != null && !pd.isHelp()) {
+            String displayedDef = Strings.isStringEmpty(def.toString()) ? "<empty string>" : def.toString();
+            outFormatted("%-" + maxLength + "s %s", "  ", "Default: " + (parameter.password() ? "********" : displayedDef));
+        }
+    }
+
+}

--- a/tooltester/src/main/java/io/dockstore/tooltester/helper/DockstoreEntryHelper.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/helper/DockstoreEntryHelper.java
@@ -59,7 +59,7 @@ public final class DockstoreEntryHelper {
         String toolId = tool.getId();
         String path = toolId.replace("#workflow/", "");
         try {
-            return workflowsApi.getPublishedWorkflowByPath(path, null, false);
+            return workflowsApi.getPublishedWorkflowByPath(path, null, null,null);
         } catch (ApiException e) {
             exceptionMessage(e, "Could not get " + path + " using the workflowsApi API", API_ERROR);
         }

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
@@ -5,10 +5,7 @@ import java.io.File;
 import com.beust.jcommander.ParameterException;
 import io.dockstore.tooltester.helper.JenkinsHelper;
 import io.dockstore.tooltester.helper.PipelineTester;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 
@@ -41,6 +38,7 @@ public class ClientTest {
     /**
      * Tests if Jenkins server is set up
      */
+    @Ignore
     @Test
     public void setupTesters() {
         client.setupTesters();
@@ -61,6 +59,7 @@ public class ClientTest {
     /**
      * Test enqueue which should run all jobs
      */
+    @Ignore
     @Test
     public void enqueue() {
         String[] argv = { "enqueue" };
@@ -81,6 +80,7 @@ public class ClientTest {
     /**
      * Test enqueue with a specific tool
      */
+    @Ignore
     @Test
     public void enqueueTool() {
         String[] argv = { "enqueue", "--tool", "quay.io/pancancer/pcawg_delly_workflow" };
@@ -91,6 +91,7 @@ public class ClientTest {
     /**
      * Test enqueue with specific verified source
      */
+    @Ignore
     @Test
     public void enqueueToolSource() {
         String[] argv = { "enqueue", "--source", "Docktesters group" };
@@ -101,6 +102,7 @@ public class ClientTest {
     /**
      * This tests the Jenkins pipeline creation
      */
+    @Ignore
     @Test
     public void createJenkinsTests() {
         String[] argv = { "sync" };
@@ -121,6 +123,7 @@ public class ClientTest {
     /**
      * This tests the Jenkins pipeline creation
      */
+    @Ignore
     @Test
     public void createJenkinsTestsSource() {
         String[] argv = { "sync", "--source", "Docktesters group"};
@@ -131,6 +134,7 @@ public class ClientTest {
     /**
      * This tests the Jenkins pipeline creation
      */
+    @Ignore
     @Test
     public void createUnverifiedJenkinsTests() {
         String[] argv = { "sync", "--source", "Docktesters group", "--tools", "quay.io/ucsc_cgl/dockstore_tool_adtex" };
@@ -151,6 +155,7 @@ public class ClientTest {
     /**
      * This prints the usage for report
      */
+    @Ignore
     @Test
     public void report() {
         String[] argv = { "report" };
@@ -161,6 +166,7 @@ public class ClientTest {
     /**
      * This reports on a specific tool
      */
+    @Ignore
     @Test
     public void reportTool() {
         String[] argv = new String[] { "report", "--tool", "quay.io/briandoconnor/dockstore-tool-md5sum" };
@@ -171,6 +177,7 @@ public class ClientTest {
     /**
      * This reports on specific tools
      */
+    @Ignore
     @Test
     public void reportTools() {
         String[] argv = new String[] { "report", "--tool", "quay.io/pancancer/pcawg-bwa-mem-workflow",
@@ -201,6 +208,7 @@ public class ClientTest {
         Assert.assertFalse(new File("tooltester/FileReport.csv").exists());
     }
 
+    @Ignore
     @Test
     public void reportInvalidTool() {
         String[] argv = new String[] { "report", "--tool", "quay.io/pancancer/pcawg-bwa" };
@@ -228,6 +236,7 @@ public class ClientTest {
     /**
      * This tests file-report with no --tool option
      */
+    @Ignore
     @Test
     public void fileReportTool() {
         String[] argv = new String[] { "file-report", "--tool", "quay.io/briandoconnor/dockstore-tool-md5sum" };

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
@@ -5,7 +5,11 @@ import java.io.File;
 import com.beust.jcommander.ParameterException;
 import io.dockstore.tooltester.helper.JenkinsHelper;
 import io.dockstore.tooltester.helper.PipelineTester;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
@@ -146,8 +146,15 @@ public class ClientTest {
      * This tests the client with no parameters
      */
     @Test
-    public void empty() {
+    public void emptyOne() {
         String[] argv = { "" };
+        main(argv);
+        Assert.assertTrue(systemOutRule.getLog().contains("Usage: autotool [options] [command] [command options]"));
+     }
+
+    @Test
+    public void emptyTwo() {
+        String[] argv = { };
         main(argv);
         Assert.assertTrue(systemOutRule.getLog().contains("Usage: autotool [options] [command] [command options]"));
     }

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
@@ -16,6 +16,9 @@ import org.junit.contrib.java.lang.system.SystemOutRule;
 import static io.dockstore.tooltester.client.cli.Client.main;
 import static io.dockstore.tooltester.helper.ExceptionHandler.COMMAND_ERROR;
 
+/**
+ * Many tests ignored due to reasons explained in this PR https://github.com/dockstore/dockstore-support/pull/448
+ */
 public class ClientTest {
     @Rule
     public final ExpectedSystemExit exit = ExpectedSystemExit.none();

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/JenkinsJobTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/JenkinsJobTest.java
@@ -4,7 +4,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.dockstore.tooltester.helper.PipelineTester;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/JenkinsJobTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/JenkinsJobTest.java
@@ -4,10 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.dockstore.tooltester.helper.PipelineTester;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
@@ -43,6 +40,7 @@ public class JenkinsJobTest {
         Assert.assertNotNull("client API could not start", client.getContainersApi());
     }
 
+    @Ignore
     @Test
     public void pipelineTestJobIT() {
         final String suffix = "id-tag";
@@ -70,6 +68,7 @@ public class JenkinsJobTest {
         //        }
     }
 
+    @Ignore
     @Test
     public void getNonExistantTest() {
         exit.expectSystemExitWithStatus(10);

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/JenkinsJobTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/JenkinsJobTest.java
@@ -21,6 +21,10 @@ import static org.junit.Assert.assertTrue;
  * @author gluu
  * @since 24/01/17
  */
+
+/**
+ * Many tests ignored due to reasons explained in this PR https://github.com/dockstore/dockstore-support/pull/448
+ */
 public class JenkinsJobTest {
     @Rule
     public TestRule watcher = new TestWatcher() {

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreEntryHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreEntryHelperTest.java
@@ -33,7 +33,6 @@ public class DockstoreEntryHelperTest {
     }
 
     @Test
-    // Should not be ignored
     public void generateLaunchToolCommand() {
         // No tool name
         Long toolId = 1055L;

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreEntryHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreEntryHelperTest.java
@@ -45,6 +45,7 @@ public class DockstoreEntryHelperTest {
         Assert.assertEquals(command, "dockstore tool launch --entry quay.io/briandoconnor/dockstore-tool-md5sum:1.0.4 --json test.json --script");
     }
 
+    @Ignore
     @Test
     public void generateLaunchWorkflowCommand() {
         // No workflow name
@@ -75,7 +76,8 @@ public class DockstoreEntryHelperTest {
         Assert.assertNotNull(dockstoreTool);
     }
 
-    @Test    @Ignore
+    @Ignore
+    @Test
     public void convertTRSToolToWorkflow() {
         Tool tool = new Tool();
         tool.setId("#workflow/github.com/briandoconnor/dockstore-workflow-md5sum");

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreEntryHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreEntryHelperTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
  * @author gluu
  * @since 03/04/19
  */
-@Ignore
 public class DockstoreEntryHelperTest {
     // This actually uses the real Dockstore staging server
     private static final String serverUrl = "https://staging.dockstore.org/api";
@@ -33,7 +32,6 @@ public class DockstoreEntryHelperTest {
         containersApi = new ContainersApi(defaultApiClient);
     }
 
-    @Ignore
     @Test
     // Should not be ignored
     public void generateLaunchToolCommand() {
@@ -67,7 +65,7 @@ public class DockstoreEntryHelperTest {
         Assert.assertEquals("dockstore workflow launch --entry github.com/ICGC-TCGA-PanCancer/pcawg-snv-indel-annotation:1.0.0 --yaml test.yaml --script", command);
     }
 
-    @Ignore
+
     @Test
     // Should not be ignored
     public void convertTRSToolToDockstoreTool() {
@@ -77,7 +75,7 @@ public class DockstoreEntryHelperTest {
         Assert.assertNotNull(dockstoreTool);
     }
 
-    @Test
+    @Test    @Ignore
     public void convertTRSToolToWorkflow() {
         Tool tool = new Tool();
         tool.setId("#workflow/github.com/briandoconnor/dockstore-workflow-md5sum");

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreEntryHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreEntryHelperTest.java
@@ -12,12 +12,14 @@ import io.swagger.client.model.Tool;
 import io.swagger.client.model.Workflow;
 import io.swagger.client.model.WorkflowVersion;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author gluu
  * @since 03/04/19
  */
+@Ignore
 public class DockstoreEntryHelperTest {
     // This actually uses the real Dockstore staging server
     private static final String serverUrl = "https://staging.dockstore.org/api";
@@ -31,7 +33,9 @@ public class DockstoreEntryHelperTest {
         containersApi = new ContainersApi(defaultApiClient);
     }
 
+    @Ignore
     @Test
+    // Should not be ignored
     public void generateLaunchToolCommand() {
         // No tool name
         Long toolId = 1055L;
@@ -63,7 +67,9 @@ public class DockstoreEntryHelperTest {
         Assert.assertEquals("dockstore workflow launch --entry github.com/ICGC-TCGA-PanCancer/pcawg-snv-indel-annotation:1.0.0 --yaml test.yaml --script", command);
     }
 
+    @Ignore
     @Test
+    // Should not be ignored
     public void convertTRSToolToDockstoreTool() {
         Tool tool = new Tool();
         tool.setId("quay.io/briandoconnor/dockstore-tool-md5sum");

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreEntryHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreEntryHelperTest.java
@@ -66,9 +66,7 @@ public class DockstoreEntryHelperTest {
         Assert.assertEquals("dockstore workflow launch --entry github.com/ICGC-TCGA-PanCancer/pcawg-snv-indel-annotation:1.0.0 --yaml test.yaml --script", command);
     }
 
-
     @Test
-    // Should not be ignored
     public void convertTRSToolToDockstoreTool() {
         Tool tool = new Tool();
         tool.setId("quay.io/briandoconnor/dockstore-tool-md5sum");

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreEntryHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreEntryHelperTest.java
@@ -19,6 +19,10 @@ import org.junit.Test;
  * @author gluu
  * @since 03/04/19
  */
+
+/**
+ * Many tests ignored due to reasons explained in this PR https://github.com/dockstore/dockstore-support/pull/448
+ */
 public class DockstoreEntryHelperTest {
     // This actually uses the real Dockstore staging server
     private static final String serverUrl = "https://staging.dockstore.org/api";


### PR DESCRIPTION
**Description**
This PR does the following,

- Upgrades the `tooltester` project to use `Java 17`
- Makes `tooltester` use `io.dockstore:swagger-java-client` version `1.13.1` as opposed to `1.9.0`
- Added `io.dockstore:bom-internal` to `tooltester` to keep version numbers consistent

To accomplish the switch to `Java 17`, I had to rewrite all of the code that used `jc.usage("COMMAND")`, as this is no longer supported. To accomplish this I took a lot of the code from [here](https://github.com/dockstore/dockstore-cli/blob/9a6293056822f7c16c83c64eae8fe105c621bd0f/dockstore-client/src/main/java/io/dockstore/client/cli/JCommanderUtility.java). Overall, it works in almost the same way it did before, with slightly different formatting of the help messages.

**BEFORE**
```
Synchronizes with Jenkins to create tests for verified tools.
Usage: sync [options]
  Options:
    --help
      Prints help for sync
      Default: false
    --source
      Tester Group
      Default: []
    --tools
      The specific tools to sync
```

**AFTER**
```
Usage: autotool sync --help
       autotool sync [parameters]

Description:
  Synchronizes with Jenkins to create tests for verified tools.


Optional parameters:
  --source <source>  Tester Group
                     Default: []
  --tools <tools>    The specific tools to sync
```
The main help message is still unchanged and is:
```
Usage: autotool [options] [command] [command options]
  Options:
    --help
      Prints help for tooltester
  Commands:
    report      Report status of verified tools tested.
      Usage: report [options]
        Options:
          --help
            Prints help for report
          --source
            Tester Group
            Default: []
          --tool
            The specific tools to report
            Default: []

    enqueue      Test verified tools on Jenkins.
      Usage: enqueue [options]
        Options:
          --help
            Prints help for enqueue
          --source
            Tester Group
            Default: []
          --tool
            The specific tools to test

    file-report      Reports the file sizes and checksum of a verified tool 
            across all tested versions.
      Usage: file-report [options]
        Options:
          --help
            Prints help for file-report
        * --tool
            The specific tool to report

    sync      Synchronizes with Jenkins to create tests for verified tools.
      Usage: sync [options]
        Options:
          --help
            Prints help for sync
          --source
            Tester Group
            Default: []
          --tools
            The specific tools to sync
```

I also had to ignore a lot of tests, as I was getting errors like,
```
Jan. 17, 2023 5:25:09 P.M. org.apache.http.impl.execchain.RetryExec execute
INFO: I/O exception (java.net.NoRouteToHostException) caught when processing request to {}->http://172.18.0.22:8080/: No route to host
Jan. 17, 2023 5:25:09 P.M. org.apache.http.impl.execchain.RetryExec execute
INFO: Retrying request to {}->http://172.18.0.22:8080/
Jan. 17, 2023 5:25:12 P.M. org.apache.http.impl.execchain.RetryExec execute
INFO: I/O exception (java.net.NoRouteToHostException) caught when processing request to {}->http://172.18.0.22:8080/: No route to host
Jan. 17, 2023 5:25:12 P.M. org.apache.http.impl.execchain.RetryExec execute
INFO: Retrying request to {}->http://172.18.0.22:8080/
Jan. 17, 2023 5:25:15 P.M. org.apache.http.impl.execchain.RetryExec execute
INFO: I/O exception (java.net.NoRouteToHostException) caught when processing request to {}->http://172.18.0.22:8080/: No route to host
Jan. 17, 2023 5:25:15 P.M. org.apache.http.impl.execchain.RetryExec execute
INFO: Retrying request to {}->http://172.18.0.22:8080/
[main] ERROR io.dockstore.tooltester.helper.ExceptionHandler - Could not connect to Jenkins server
[main] ERROR io.dockstore.tooltester.helper.ExceptionHandler - java.net.NoRouteToHostException: No route to host
```
and Denis said that these tests were not necessary for what we want to accomplish with `tooltester`.

**Issues**
[SEAB-5175](https://ucsc-cgl.atlassian.net/browse/SEAB-5175)
[SEAB-5178](https://ucsc-cgl.atlassian.net/browse/SEAB-5178)



[SEAB-5175]: https://ucsc-cgl.atlassian.net/browse/SEAB-5175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ