### PR TITLE
Upgraded Tooltester to Junit 5

### DIFF
--- a/tooltester/pom.xml
+++ b/tooltester/pom.xml
@@ -36,8 +36,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.url>scm:git:git@github.com:dockstore/dockstore-support.git</github.url>
-        <junit-version>4.13.2</junit-version>
         <slf4j.version>1.7.36</slf4j.version>
+        <system-stubs.version>2.0.1</system-stubs.version>
         <jackson.version>2.13.4</jackson.version>
         <aws.version>1.11.86</aws.version>
         <dockstore.core.version>1.13.1</dockstore.core.version>
@@ -335,13 +335,13 @@
         <dependency>
             <groupId>uk.org.webcompere</groupId>
             <artifactId>system-stubs-jupiter</artifactId>
-            <version>1.1.0</version>
+            <version>${system-stubs.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>uk.org.webcompere</groupId>
             <artifactId>system-stubs-core</artifactId>
-            <version>1.1.0</version>
+            <version>${system-stubs.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/tooltester/pom.xml
+++ b/tooltester/pom.xml
@@ -326,26 +326,22 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
-        <!-- https://mvnrepository.com/artifact/junit/junit -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
-
-        </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>1.19.0</version>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-jupiter</artifactId>
+            <version>1.1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-core</artifactId>
+            <version>1.1.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -381,20 +377,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.9.1</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>5.9.1</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- For AWS integration END -->

--- a/tooltester/pom.xml
+++ b/tooltester/pom.xml
@@ -41,6 +41,8 @@
         <jackson.version>2.13.4</jackson.version>
         <aws.version>1.11.86</aws.version>
         <dockstore.core.version>1.13.1</dockstore.core.version>
+        <maven-surefire.version>3.0.0-M5</maven-surefire.version>
+        <maven-failsafe.version>2.22.2</maven-failsafe.version>
     </properties>
 
     <organization>
@@ -713,7 +715,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>${maven-surefire.version}</version>
                 <executions>
                     <execution>
                         <id>test</id>
@@ -726,7 +728,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>${maven-failsafe.version}</version>
                 <executions>
                     <execution>
                         <id>integration-test</id>

--- a/tooltester/pom.xml
+++ b/tooltester/pom.xml
@@ -378,6 +378,24 @@
             <version>2.2.11</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.1</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <!-- For AWS integration END -->
     </dependencies>

--- a/tooltester/src/test/java/io/dockstore/tooltester/S3ClientTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/S3ClientTest.java
@@ -2,8 +2,8 @@ package io.dockstore.tooltester;
 
 import java.io.UnsupportedEncodingException;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author gluu
@@ -29,13 +29,13 @@ public class S3ClientTest {
     @Test
     public void convertToolIdToPartialKey() throws UnsupportedEncodingException {
         String toolId = "#workflow/github.com/ENCODE-DCC/pipeline-container/encode-mapping-cwl";
-        Assert.assertEquals("workflow/github.com/ENCODE-DCC/pipeline-container%2Fencode-mapping-cwl", S3Client.convertToolIdToPartialKey(toolId));
+        Assertions.assertEquals("workflow/github.com/ENCODE-DCC/pipeline-container%2Fencode-mapping-cwl", S3Client.convertToolIdToPartialKey(toolId));
         toolId = "#workflow/github.com/ENCODE-DCC/pipeline-container";
-        Assert.assertEquals("workflow/github.com/ENCODE-DCC/pipeline-container", S3Client.convertToolIdToPartialKey(toolId));
+        Assertions.assertEquals("workflow/github.com/ENCODE-DCC/pipeline-container", S3Client.convertToolIdToPartialKey(toolId));
         toolId = "quay.io/pancancer/pcawg-bwa-mem-workflow";
-        Assert.assertEquals("tool/quay.io/pancancer/pcawg-bwa-mem-workflow", S3Client.convertToolIdToPartialKey(toolId));
+        Assertions.assertEquals("tool/quay.io/pancancer/pcawg-bwa-mem-workflow", S3Client.convertToolIdToPartialKey(toolId));
         toolId = "quay.io/pancancer/pcawg-bwa-mem-workflow/thing";
-        Assert.assertEquals("tool/quay.io/pancancer/pcawg-bwa-mem-workflow%2Fthing", S3Client.convertToolIdToPartialKey(toolId));
+        Assertions.assertEquals("tool/quay.io/pancancer/pcawg-bwa-mem-workflow%2Fthing", S3Client.convertToolIdToPartialKey(toolId));
     }
 
 }

--- a/tooltester/src/test/java/io/dockstore/tooltester/S3ClientTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/S3ClientTest.java
@@ -2,8 +2,9 @@ package io.dockstore.tooltester;
 
 import java.io.UnsupportedEncodingException;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author gluu
@@ -29,13 +30,13 @@ public class S3ClientTest {
     @Test
     public void convertToolIdToPartialKey() throws UnsupportedEncodingException {
         String toolId = "#workflow/github.com/ENCODE-DCC/pipeline-container/encode-mapping-cwl";
-        Assertions.assertEquals("workflow/github.com/ENCODE-DCC/pipeline-container%2Fencode-mapping-cwl", S3Client.convertToolIdToPartialKey(toolId));
+        assertEquals("workflow/github.com/ENCODE-DCC/pipeline-container%2Fencode-mapping-cwl", S3Client.convertToolIdToPartialKey(toolId));
         toolId = "#workflow/github.com/ENCODE-DCC/pipeline-container";
-        Assertions.assertEquals("workflow/github.com/ENCODE-DCC/pipeline-container", S3Client.convertToolIdToPartialKey(toolId));
+        assertEquals("workflow/github.com/ENCODE-DCC/pipeline-container", S3Client.convertToolIdToPartialKey(toolId));
         toolId = "quay.io/pancancer/pcawg-bwa-mem-workflow";
-        Assertions.assertEquals("tool/quay.io/pancancer/pcawg-bwa-mem-workflow", S3Client.convertToolIdToPartialKey(toolId));
+        assertEquals("tool/quay.io/pancancer/pcawg-bwa-mem-workflow", S3Client.convertToolIdToPartialKey(toolId));
         toolId = "quay.io/pancancer/pcawg-bwa-mem-workflow/thing";
-        Assertions.assertEquals("tool/quay.io/pancancer/pcawg-bwa-mem-workflow%2Fthing", S3Client.convertToolIdToPartialKey(toolId));
+        assertEquals("tool/quay.io/pancancer/pcawg-bwa-mem-workflow%2Fthing", S3Client.convertToolIdToPartialKey(toolId));
     }
 
 }

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
@@ -5,73 +5,81 @@ import java.io.File;
 import com.beust.jcommander.ParameterException;
 import io.dockstore.tooltester.helper.JenkinsHelper;
 import io.dockstore.tooltester.helper.PipelineTester;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
-import org.junit.contrib.java.lang.system.SystemOutRule;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.stream.SystemErr;
+import uk.org.webcompere.systemstubs.stream.SystemOut;
+import uk.org.webcompere.systemstubs.stream.output.NoopStream;
 
 import static io.dockstore.tooltester.client.cli.Client.main;
 import static io.dockstore.tooltester.helper.ExceptionHandler.COMMAND_ERROR;
+import static uk.org.webcompere.systemstubs.SystemStubs.catchSystemExit;
 
 /**
  * Many tests ignored due to reasons explained in this PR https://github.com/dockstore/dockstore-support/pull/448
  */
-public class ClientTest {
-    @Rule
-    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
 
-    @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+@ExtendWith(SystemStubsExtension.class)
+public class ClientTest {
+    @SystemStub
+    private SystemOut systemOut;
+
+    @SystemStub
+    private SystemErr systemErr;
 
     private Client client;
 
-    @Before
+    @BeforeEach
     public void initialize() {
         this.client = new Client();
         this.client.setupClientEnvironment();
-        Assert.assertNotNull("client API could not start", client.getContainersApi());
+        Assertions.assertNotNull(client.getContainersApi(), "client API could not start");
     }
 
     @Test
     public void setupEnvironment() {
         client = new Client();
         client.setupClientEnvironment();
-        Assert.assertNotNull("client API could not start", client.getContainersApi());
+        Assertions.assertNotNull(client.getContainersApi(), "client API could not start");
     }
 
     /**
      * Tests if Jenkins server is set up
      */
-    @Ignore
+    @Disabled
     @Test
     public void setupTesters() {
         client.setupTesters();
         PipelineTester pipelineTester = client.getPipelineTester();
-        Assert.assertNotNull("Jenkins server can not be reached", pipelineTester.getJenkins());
+        Assertions.assertNotNull(pipelineTester.getJenkins(), "Jenkins server can not be reached");
     }
 
     /**
      * Test with unknown command
      */
     @Test
-    public void unknownCommand() {
+    public void unknownCommand() throws Exception {
         String[] argv = { "mmmrrrggglll" };
-        exit.expectSystemExitWithStatus(COMMAND_ERROR);
-        main(argv);
+        int exitCode = catchSystemExit(() -> {
+            main(argv);
+        });
+        Assertions.assertEquals(COMMAND_ERROR, exitCode);
     }
 
     /**
      * Test enqueue which should run all jobs
      */
-    @Ignore
+    @Disabled
     @Test
     public void enqueue() {
         String[] argv = { "enqueue" };
         main(argv);
-        Assert.assertTrue(systemOutRule.getLog().isEmpty());
+        Assertions.assertTrue(systemOut.getText().isEmpty());
     }
 
     /**
@@ -81,40 +89,40 @@ public class ClientTest {
     public void enqueueHelp() {
         String[] argv = { "enqueue", "--help" };
         main(argv);
-        Assert.assertTrue(systemOutRule.getLog().contains("Test verified tools on Jenkins."));
+        Assertions.assertTrue(systemOut.getText().contains("Test verified tools on Jenkins."));
     }
 
     /**
      * Test enqueue with a specific tool
      */
-    @Ignore
+    @Disabled
     @Test
     public void enqueueTool() {
         String[] argv = { "enqueue", "--tool", "quay.io/pancancer/pcawg_delly_workflow" };
         main(argv);
-        Assert.assertTrue(systemOutRule.getLog().isEmpty());
+        Assertions.assertTrue(systemOut.getText().isEmpty());
     }
 
     /**
      * Test enqueue with specific verified source
      */
-    @Ignore
+    @Disabled
     @Test
     public void enqueueToolSource() {
         String[] argv = { "enqueue", "--source", "Docktesters group" };
         main(argv);
-        Assert.assertTrue(systemOutRule.getLog().isEmpty());
+        Assertions.assertTrue(systemOut.getText().isEmpty());
     }
 
     /**
      * This tests the Jenkins pipeline creation
      */
-    @Ignore
+    @Disabled
     @Test
     public void createJenkinsTests() {
         String[] argv = { "sync" };
         main(argv);
-        Assert.assertTrue(systemOutRule.getLog().isEmpty());
+        Assertions.assertTrue(systemOut.getText().isEmpty());
     }
 
     /**
@@ -124,29 +132,29 @@ public class ClientTest {
     public void syncHelp() {
         String[] argv = { "sync", "--help" };
         main(argv);
-        Assert.assertTrue(systemOutRule.getLog().contains("Synchronizes with Jenkins to create tests for verified tools."));
+        Assertions.assertTrue(systemOut.getText().contains("Synchronizes with Jenkins to create tests for verified tools."));
     }
 
     /**
      * This tests the Jenkins pipeline creation
      */
-    @Ignore
+    @Disabled
     @Test
     public void createJenkinsTestsSource() {
         String[] argv = { "sync", "--source", "Docktesters group"};
         main(argv);
-        Assert.assertTrue(systemOutRule.getLog().isEmpty());
+        Assertions.assertTrue(systemOut.getText().isEmpty());
     }
 
     /**
      * This tests the Jenkins pipeline creation
      */
-    @Ignore
+    @Disabled
     @Test
     public void createUnverifiedJenkinsTests() {
         String[] argv = { "sync", "--source", "Docktesters group", "--tools", "quay.io/ucsc_cgl/dockstore_tool_adtex" };
         main(argv);
-        Assert.assertTrue(systemOutRule.getLog().isEmpty());
+        Assertions.assertTrue(systemOut.getText().isEmpty());
     }
 
     /**
@@ -156,20 +164,20 @@ public class ClientTest {
     public void emptyOne() {
         String[] argv = { "" };
         main(argv);
-        Assert.assertTrue(systemOutRule.getLog().contains("Usage: autotool [options] [command] [command options]"));
+        Assertions.assertTrue(systemOut.getText().contains("Usage: autotool [options] [command] [command options]"));
      }
 
     @Test
     public void emptyTwo() {
         String[] argv = { };
         main(argv);
-        Assert.assertTrue(systemOutRule.getLog().contains("Usage: autotool [options] [command] [command options]"));
+        Assertions.assertTrue(systemOut.getText().contains("Usage: autotool [options] [command] [command options]"));
     }
 
     /**
      * This prints the usage for report
      */
-    @Ignore
+    @Disabled
     @Test
     public void report() {
         String[] argv = { "report" };
@@ -180,7 +188,7 @@ public class ClientTest {
     /**
      * This reports on a specific tool
      */
-    @Ignore
+    @Disabled
     @Test
     public void reportTool() {
         String[] argv = new String[] { "report", "--tool", "quay.io/briandoconnor/dockstore-tool-md5sum" };
@@ -191,7 +199,7 @@ public class ClientTest {
     /**
      * This reports on specific tools
      */
-    @Ignore
+    @Disabled
     @Test
     public void reportTools() {
         String[] argv = new String[] { "report", "--tool", "quay.io/pancancer/pcawg-bwa-mem-workflow",
@@ -202,27 +210,27 @@ public class ClientTest {
     }
 
     private void assertReport() {
-        Assert.assertTrue(systemOutRule.getLog().contains("Tool/Workflow ID"));
-        Assert.assertTrue(systemOutRule.getLog().contains("DATE"));
-        Assert.assertTrue(systemOutRule.getLog().contains("Version"));
-        Assert.assertTrue(systemOutRule.getLog().contains("Engine"));
-        Assert.assertTrue(systemOutRule.getLog().contains("Action Performed"));
-        Assert.assertTrue(systemOutRule.getLog().contains("Runtime"));
-        Assert.assertTrue(systemOutRule.getLog().contains("Status of Test Files"));
-        Assert.assertFalse(new File("tooltester/Report.csv").exists());
+        Assertions.assertTrue(systemOut.getText().contains("Tool/Workflow ID"));
+        Assertions.assertTrue(systemOut.getText().contains("DATE"));
+        Assertions.assertTrue(systemOut.getText().contains("Version"));
+        Assertions.assertTrue(systemOut.getText().contains("Engine"));
+        Assertions.assertTrue(systemOut.getText().contains("Action Performed"));
+        Assertions.assertTrue(systemOut.getText().contains("Runtime"));
+        Assertions.assertTrue(systemOut.getText().contains("Status of Test Files"));
+        Assertions.assertFalse(new File("tooltester/Report.csv").exists());
     }
 
     private void assertFileReport() {
-        Assert.assertTrue(systemOutRule.getLog().contains("Build ID"));
-        Assert.assertTrue(systemOutRule.getLog().contains("Tag"));
-        Assert.assertTrue(systemOutRule.getLog().contains("File Name"));
-        Assert.assertTrue(systemOutRule.getLog().contains("CWL ID"));
-        Assert.assertTrue(systemOutRule.getLog().contains("md5sum"));
-        Assert.assertTrue(systemOutRule.getLog().contains("File Size"));
-        Assert.assertFalse(new File("tooltester/FileReport.csv").exists());
+        Assertions.assertTrue(systemOut.getText().contains("Build ID"));
+        Assertions.assertTrue(systemOut.getText().contains("Tag"));
+        Assertions.assertTrue(systemOut.getText().contains("File Name"));
+        Assertions.assertTrue(systemOut.getText().contains("CWL ID"));
+        Assertions.assertTrue(systemOut.getText().contains("md5sum"));
+        Assertions.assertTrue(systemOut.getText().contains("File Size"));
+        Assertions.assertFalse(new File("tooltester/FileReport.csv").exists());
     }
 
-    @Ignore
+    @Disabled
     @Test
     public void reportInvalidTool() {
         String[] argv = new String[] { "report", "--tool", "quay.io/pancancer/pcawg-bwa" };
@@ -234,23 +242,23 @@ public class ClientTest {
     public void testCleanSuffix() {
         final String testSuffix1 = "quay.io/pancancer/pcawg-bwa";
         final String testSuffix2 = "#workflow/pancancer/pcawg-bwa";
-        Assert.assertEquals("quay.io-pancancer-pcawg-bwa", JenkinsHelper.cleanSuffx(testSuffix1));
-        Assert.assertEquals("-workflow-pancancer-pcawg-bwa", JenkinsHelper.cleanSuffx(testSuffix2));
+        Assertions.assertEquals("quay.io-pancancer-pcawg-bwa", JenkinsHelper.cleanSuffx(testSuffix1));
+        Assertions.assertEquals("-workflow-pancancer-pcawg-bwa", JenkinsHelper.cleanSuffx(testSuffix2));
     }
 
     /**
      * This tests file-report with no --tool option
      */
-    @Test(expected = ParameterException.class)
+    @Test
     public void fileReport() {
         String[] argv = new String[] { "file-report" };
-        main(argv);
+        Assertions.assertThrows(ParameterException.class, () -> main(argv));
     }
 
     /**
      * This tests file-report with no --tool option
      */
-    @Ignore
+    @Disabled
     @Test
     public void fileReportTool() {
         String[] argv = new String[] { "file-report", "--tool", "quay.io/briandoconnor/dockstore-tool-md5sum" };
@@ -265,8 +273,8 @@ public class ClientTest {
     public void fileReportHelp() {
         String[] argv = new String[] { "file-report", "--help" };
         main(argv);
-        Assert.assertTrue(
-                systemOutRule.getLog().contains("Reports the file sizes and checksum of a verified tool across all tested versions."));
+        Assertions.assertTrue(
+                systemOut.getText().contains("Reports the file sizes and checksum of a verified tool across all tested versions."));
     }
 
     /**
@@ -276,7 +284,7 @@ public class ClientTest {
     public void reportHelp() {
         String[] argv = { "report", "--help" };
         main(argv);
-        Assert.assertTrue(systemOutRule.getLog().contains("Report status of verified tools tested."));
+        Assertions.assertTrue(systemOut.getText().contains("Report status of verified tools tested."));
     }
 
     /**
@@ -286,6 +294,6 @@ public class ClientTest {
     public void mainHelp() {
         String[] argv = { "--help" };
         main(argv);
-        Assert.assertTrue(systemOutRule.getLog().contains("Usage: autotool [options] [command] [command options]"));
+        Assertions.assertTrue(systemOut.getText().contains("Usage: autotool [options] [command] [command options]"));
     }
 }

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
@@ -14,7 +14,6 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 import uk.org.webcompere.systemstubs.stream.SystemErr;
 import uk.org.webcompere.systemstubs.stream.SystemOut;
-import uk.org.webcompere.systemstubs.stream.output.NoopStream;
 
 import static io.dockstore.tooltester.client.cli.Client.main;
 import static io.dockstore.tooltester.helper.ExceptionHandler.COMMAND_ERROR;

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
@@ -5,7 +5,11 @@ import java.io.File;
 import com.beust.jcommander.ParameterException;
 import io.dockstore.tooltester.helper.JenkinsHelper;
 import io.dockstore.tooltester.helper.PipelineTester;
-import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -37,14 +41,14 @@ public class ClientTest {
     public void initialize() {
         this.client = new Client();
         this.client.setupClientEnvironment();
-        Assertions.assertNotNull(client.getContainersApi(), "client API could not start");
+        assertNotNull(client.getContainersApi(), "client API could not start");
     }
 
     @Test
     public void setupEnvironment() {
         client = new Client();
         client.setupClientEnvironment();
-        Assertions.assertNotNull(client.getContainersApi(), "client API could not start");
+        assertNotNull(client.getContainersApi(), "client API could not start");
     }
 
     /**
@@ -55,7 +59,7 @@ public class ClientTest {
     public void setupTesters() {
         client.setupTesters();
         PipelineTester pipelineTester = client.getPipelineTester();
-        Assertions.assertNotNull(pipelineTester.getJenkins(), "Jenkins server can not be reached");
+        assertNotNull(pipelineTester.getJenkins(), "Jenkins server can not be reached");
     }
 
     /**
@@ -67,7 +71,7 @@ public class ClientTest {
         int exitCode = catchSystemExit(() -> {
             main(argv);
         });
-        Assertions.assertEquals(COMMAND_ERROR, exitCode);
+        assertEquals(COMMAND_ERROR, exitCode);
     }
 
     /**
@@ -78,7 +82,7 @@ public class ClientTest {
     public void enqueue() {
         String[] argv = { "enqueue" };
         main(argv);
-        Assertions.assertTrue(systemOut.getText().isEmpty());
+        assertTrue(systemOut.getText().isEmpty());
     }
 
     /**
@@ -88,7 +92,7 @@ public class ClientTest {
     public void enqueueHelp() {
         String[] argv = { "enqueue", "--help" };
         main(argv);
-        Assertions.assertTrue(systemOut.getText().contains("Test verified tools on Jenkins."));
+        assertTrue(systemOut.getText().contains("Test verified tools on Jenkins."));
     }
 
     /**
@@ -99,7 +103,7 @@ public class ClientTest {
     public void enqueueTool() {
         String[] argv = { "enqueue", "--tool", "quay.io/pancancer/pcawg_delly_workflow" };
         main(argv);
-        Assertions.assertTrue(systemOut.getText().isEmpty());
+        assertTrue(systemOut.getText().isEmpty());
     }
 
     /**
@@ -110,7 +114,7 @@ public class ClientTest {
     public void enqueueToolSource() {
         String[] argv = { "enqueue", "--source", "Docktesters group" };
         main(argv);
-        Assertions.assertTrue(systemOut.getText().isEmpty());
+        assertTrue(systemOut.getText().isEmpty());
     }
 
     /**
@@ -121,7 +125,7 @@ public class ClientTest {
     public void createJenkinsTests() {
         String[] argv = { "sync" };
         main(argv);
-        Assertions.assertTrue(systemOut.getText().isEmpty());
+        assertTrue(systemOut.getText().isEmpty());
     }
 
     /**
@@ -131,7 +135,7 @@ public class ClientTest {
     public void syncHelp() {
         String[] argv = { "sync", "--help" };
         main(argv);
-        Assertions.assertTrue(systemOut.getText().contains("Synchronizes with Jenkins to create tests for verified tools."));
+        assertTrue(systemOut.getText().contains("Synchronizes with Jenkins to create tests for verified tools."));
     }
 
     /**
@@ -142,7 +146,7 @@ public class ClientTest {
     public void createJenkinsTestsSource() {
         String[] argv = { "sync", "--source", "Docktesters group"};
         main(argv);
-        Assertions.assertTrue(systemOut.getText().isEmpty());
+        assertTrue(systemOut.getText().isEmpty());
     }
 
     /**
@@ -153,7 +157,7 @@ public class ClientTest {
     public void createUnverifiedJenkinsTests() {
         String[] argv = { "sync", "--source", "Docktesters group", "--tools", "quay.io/ucsc_cgl/dockstore_tool_adtex" };
         main(argv);
-        Assertions.assertTrue(systemOut.getText().isEmpty());
+        assertTrue(systemOut.getText().isEmpty());
     }
 
     /**
@@ -163,14 +167,14 @@ public class ClientTest {
     public void emptyOne() {
         String[] argv = { "" };
         main(argv);
-        Assertions.assertTrue(systemOut.getText().contains("Usage: autotool [options] [command] [command options]"));
+        assertTrue(systemOut.getText().contains("Usage: autotool [options] [command] [command options]"));
      }
 
     @Test
     public void emptyTwo() {
         String[] argv = { };
         main(argv);
-        Assertions.assertTrue(systemOut.getText().contains("Usage: autotool [options] [command] [command options]"));
+        assertTrue(systemOut.getText().contains("Usage: autotool [options] [command] [command options]"));
     }
 
     /**
@@ -209,24 +213,24 @@ public class ClientTest {
     }
 
     private void assertReport() {
-        Assertions.assertTrue(systemOut.getText().contains("Tool/Workflow ID"));
-        Assertions.assertTrue(systemOut.getText().contains("DATE"));
-        Assertions.assertTrue(systemOut.getText().contains("Version"));
-        Assertions.assertTrue(systemOut.getText().contains("Engine"));
-        Assertions.assertTrue(systemOut.getText().contains("Action Performed"));
-        Assertions.assertTrue(systemOut.getText().contains("Runtime"));
-        Assertions.assertTrue(systemOut.getText().contains("Status of Test Files"));
-        Assertions.assertFalse(new File("tooltester/Report.csv").exists());
+        assertTrue(systemOut.getText().contains("Tool/Workflow ID"));
+        assertTrue(systemOut.getText().contains("DATE"));
+        assertTrue(systemOut.getText().contains("Version"));
+        assertTrue(systemOut.getText().contains("Engine"));
+        assertTrue(systemOut.getText().contains("Action Performed"));
+        assertTrue(systemOut.getText().contains("Runtime"));
+        assertTrue(systemOut.getText().contains("Status of Test Files"));
+        assertFalse(new File("tooltester/Report.csv").exists());
     }
 
     private void assertFileReport() {
-        Assertions.assertTrue(systemOut.getText().contains("Build ID"));
-        Assertions.assertTrue(systemOut.getText().contains("Tag"));
-        Assertions.assertTrue(systemOut.getText().contains("File Name"));
-        Assertions.assertTrue(systemOut.getText().contains("CWL ID"));
-        Assertions.assertTrue(systemOut.getText().contains("md5sum"));
-        Assertions.assertTrue(systemOut.getText().contains("File Size"));
-        Assertions.assertFalse(new File("tooltester/FileReport.csv").exists());
+        assertTrue(systemOut.getText().contains("Build ID"));
+        assertTrue(systemOut.getText().contains("Tag"));
+        assertTrue(systemOut.getText().contains("File Name"));
+        assertTrue(systemOut.getText().contains("CWL ID"));
+        assertTrue(systemOut.getText().contains("md5sum"));
+        assertTrue(systemOut.getText().contains("File Size"));
+        assertFalse(new File("tooltester/FileReport.csv").exists());
     }
 
     @Disabled
@@ -241,8 +245,8 @@ public class ClientTest {
     public void testCleanSuffix() {
         final String testSuffix1 = "quay.io/pancancer/pcawg-bwa";
         final String testSuffix2 = "#workflow/pancancer/pcawg-bwa";
-        Assertions.assertEquals("quay.io-pancancer-pcawg-bwa", JenkinsHelper.cleanSuffx(testSuffix1));
-        Assertions.assertEquals("-workflow-pancancer-pcawg-bwa", JenkinsHelper.cleanSuffx(testSuffix2));
+        assertEquals("quay.io-pancancer-pcawg-bwa", JenkinsHelper.cleanSuffx(testSuffix1));
+        assertEquals("-workflow-pancancer-pcawg-bwa", JenkinsHelper.cleanSuffx(testSuffix2));
     }
 
     /**
@@ -251,7 +255,7 @@ public class ClientTest {
     @Test
     public void fileReport() {
         String[] argv = new String[] { "file-report" };
-        Assertions.assertThrows(ParameterException.class, () -> main(argv));
+        assertThrows(ParameterException.class, () -> main(argv));
     }
 
     /**
@@ -272,7 +276,7 @@ public class ClientTest {
     public void fileReportHelp() {
         String[] argv = new String[] { "file-report", "--help" };
         main(argv);
-        Assertions.assertTrue(
+        assertTrue(
                 systemOut.getText().contains("Reports the file sizes and checksum of a verified tool across all tested versions."));
     }
 
@@ -283,7 +287,7 @@ public class ClientTest {
     public void reportHelp() {
         String[] argv = { "report", "--help" };
         main(argv);
-        Assertions.assertTrue(systemOut.getText().contains("Report status of verified tools tested."));
+        assertTrue(systemOut.getText().contains("Report status of verified tools tested."));
     }
 
     /**
@@ -293,6 +297,6 @@ public class ClientTest {
     public void mainHelp() {
         String[] argv = { "--help" };
         main(argv);
-        Assertions.assertTrue(systemOut.getText().contains("Usage: autotool [options] [command] [command options]"));
+        assertTrue(systemOut.getText().contains("Usage: autotool [options] [command] [command options]"));
     }
 }

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/JenkinsJobTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/JenkinsJobTest.java
@@ -26,12 +26,6 @@ import static uk.org.webcompere.systemstubs.SystemStubs.catchSystemExit;
  */
 @ExtendWith(SystemStubsExtension.class)
 public class JenkinsJobTest {
-//    @Rule
-//    public TestRule watcher = new TestWatcher() {
-//        protected void starting(Description description) {
-//            System.out.println("Starting test: " + description.getMethodName());
-//        }
-//    };
 
     /**
      * This tests if a parameter file test can be created and ran.

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/JenkinsJobTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/JenkinsJobTest.java
@@ -5,7 +5,9 @@ import java.util.Map;
 
 import io.dockstore.tooltester.helper.PipelineTester;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Assertions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +41,7 @@ public class JenkinsJobTest {
     public void initialize() {
         client = new Client();
         client.setupClientEnvironment();
-        Assertions.assertNotNull(client.getContainersApi(), "client API could not start");
+        assertNotNull(client.getContainersApi(), "client API could not start");
     }
 
     @Disabled
@@ -47,7 +49,7 @@ public class JenkinsJobTest {
     public void pipelineTestJobIT() {
         final String suffix = "id-tag";
         client.setupTesters();
-        Assertions.assertNotNull(client.getPipelineTester().getJenkins(), "Jenkins server can not be reached");
+        assertNotNull(client.getPipelineTester().getJenkins(), "Jenkins server can not be reached");
         client.setupTesters();
         PipelineTester pipelineTester = client.getPipelineTester();
         String jenkinsJobTemplate = pipelineTester.getJenkinsJobTemplate();
@@ -62,7 +64,7 @@ public class JenkinsJobTest {
 
         pipelineTester.runTest(suffix, map);
         String status = pipelineTester.getTestResults(suffix).get("status");
-        Assertions.assertNotNull(status, "Status is not SUCCESS: ");
+        assertNotNull(status, "Status is not SUCCESS: ");
         //        try {
         //            client.getJenkins().deleteJob("PipelineTest" + "-" + suffix, true);
         //        } catch (IOException e) {
@@ -76,9 +78,9 @@ public class JenkinsJobTest {
         int exitCode = catchSystemExit(() -> {
             client.setupTesters();
         });
-        Assertions.assertEquals(10, exitCode);
+        assertEquals(10, exitCode);
         PipelineTester pipelineTester = client.getPipelineTester();
-        Assertions.assertNotNull(pipelineTester.getJenkins(), "Jenkins server can not be reached");
+        assertNotNull(pipelineTester.getJenkins(), "Jenkins server can not be reached");
         pipelineTester.getTestResults("SuffixOfATestThatShouldNotExist");
     }
 }

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/TimeHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/TimeHelperTest.java
@@ -4,8 +4,10 @@ import java.text.ParseException;
 import java.util.Objects;
 
 import io.dockstore.tooltester.helper.TimeHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author gluu
@@ -15,7 +17,7 @@ public class TimeHelperTest {
     @Test
     public void durationToString() throws Exception {
         String durationString = TimeHelper.durationToString(Long.valueOf(3700000));
-        Assertions.assertTrue(durationString.equals("1h 2m"), "Incorrect time calculated, expected \"1h 2m\" but got " + durationString);
+        assertTrue(durationString.equals("1h 2m"), "Incorrect time calculated, expected \"1h 2m\" but got " + durationString);
     }
 
     @Test
@@ -26,14 +28,14 @@ public class TimeHelperTest {
         } catch (ParseException e) {
             System.out.println("Could not convert date");
         }
-        Assertions.assertTrue(Objects.equals(time, "2017-02-22 15:36"), "Incorrect date calculated, expected \"2017-02-22 15:36\" but got " + time);
+        assertTrue(Objects.equals(time, "2017-02-22 15:36"), "Incorrect date calculated, expected \"2017-02-22 15:36\" but got " + time);
     }
 
     @Test
     public void datetimeToEpoch() {
         String startTime = "2019-04-05T15:21:44.219+0000";
         String epochTimeString = TimeHelper.timeFormatToEpoch(startTime);
-        Assertions.assertEquals("1554477704219", epochTimeString);
+        assertEquals("1554477704219", epochTimeString);
     }
 
 

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/TimeHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/TimeHelperTest.java
@@ -4,8 +4,8 @@ import java.text.ParseException;
 import java.util.Objects;
 
 import io.dockstore.tooltester.helper.TimeHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author gluu
@@ -15,7 +15,7 @@ public class TimeHelperTest {
     @Test
     public void durationToString() throws Exception {
         String durationString = TimeHelper.durationToString(Long.valueOf(3700000));
-        Assert.assertTrue("Incorrect time calculated, expected \"1h 2m\" but got " + durationString, durationString.equals("1h 2m"));
+        Assertions.assertTrue(durationString.equals("1h 2m"), "Incorrect time calculated, expected \"1h 2m\" but got " + durationString);
     }
 
     @Test
@@ -26,15 +26,14 @@ public class TimeHelperTest {
         } catch (ParseException e) {
             System.out.println("Could not convert date");
         }
-        Assert.assertTrue("Incorrect date calculated, expected \"2017-02-22 15:36\" but got " + time,
-                Objects.equals(time, "2017-02-22 15:36"));
+        Assertions.assertTrue(Objects.equals(time, "2017-02-22 15:36"), "Incorrect date calculated, expected \"2017-02-22 15:36\" but got " + time);
     }
 
     @Test
     public void datetimeToEpoch() {
         String startTime = "2019-04-05T15:21:44.219+0000";
         String epochTimeString = TimeHelper.timeFormatToEpoch(startTime);
-        Assert.assertEquals("1554477704219", epochTimeString);
+        Assertions.assertEquals("1554477704219", epochTimeString);
     }
 
 

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreConfigHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreConfigHelperTest.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import com.beust.jcommander.ParameterException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.jupiter.api.extension.ExtendWith;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreConfigHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreConfigHelperTest.java
@@ -2,7 +2,6 @@ package io.dockstore.tooltester.helper;
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreConfigHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreConfigHelperTest.java
@@ -2,52 +2,59 @@ package io.dockstore.tooltester.helper;
 
 import java.io.IOException;
 
-import org.junit.Rule;
-import org.junit.Test;
+import com.beust.jcommander.ParameterException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
-import static org.junit.Assert.*;
+import static io.dockstore.tooltester.client.cli.Client.main;
+import static io.dockstore.tooltester.helper.ExceptionHandler.COMMAND_ERROR;
+import static uk.org.webcompere.systemstubs.SystemStubs.catchSystemExit;
+
 
 /**
  * @author gluu
  * @since 05/12/17
  */
+@ExtendWith(SystemStubsExtension.class)
 public class DockstoreConfigHelperTest {
-    @Rule
-    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
 
     @Test
     public void testCwltoolConfig() {
         final String url = "https://staging.dockstore.org:8443";
         String cwltoolConfig = DockstoreConfigHelper.getConfig(url, "cwltool");
-        assertEquals("token: test\\nserver-url: https://staging.dockstore.org:8443\\ncwlrunner: cwltool\n", cwltoolConfig);
+        Assertions.assertEquals("token: test\\nserver-url: https://staging.dockstore.org:8443\\ncwlrunner: cwltool\n", cwltoolConfig);
     }
 
     @Test
     public void testToilConfig() throws IOException {
         final String url = "https://staging.dockstore.org:8443";
         String toilConfig = DockstoreConfigHelper.getConfig(url, "toil");
-        assertEquals("token: test\\nserver-url: https://staging.dockstore.org:8443\\ncwlrunner: toil\n", toilConfig);
+        Assertions.assertEquals("token: test\\nserver-url: https://staging.dockstore.org:8443\\ncwlrunner: toil\n", toilConfig);
     }
 
     @Test
     public void testCromwellConfig() throws IOException {
         final String url = "https://staging.dockstore.org:8443";
         String toilConfig = DockstoreConfigHelper.getConfig(url, "cromwell");
-        assertEquals("token: test\\nserver-url: https://staging.dockstore.org:8443\\n# cromwell-version = 36\n", toilConfig);
+        Assertions.assertEquals("token: test\\nserver-url: https://staging.dockstore.org:8443\\n# cromwell-version = 36\n", toilConfig);
     }
 
     @Test
     public void testCwlrunnerConfig() throws IOException {
         final String url = "https://staging.dockstore.org:8443";
         String toilConfig = DockstoreConfigHelper.getConfig(url, "cwl-runner");
-        assertEquals("token: test\\nserver-url: https://staging.dockstore.org:8443\\ncwlrunner: cwl-runner\n", toilConfig);
+        Assertions.assertEquals("token: test\\nserver-url: https://staging.dockstore.org:8443\\ncwlrunner: cwl-runner\n", toilConfig);
     }
 
     @Test
-    public void testPotatoConfig() {
+    public void testPotatoConfig() throws Exception {
         final String url = "https://staging.dockstore.org:8443";
-        exit.expectSystemExitWithStatus(ExceptionHandler.CLIENT_ERROR);
-        String rabixConfig = DockstoreConfigHelper.getConfig(url, "potato");
+        int exitCode = catchSystemExit(() -> {
+            DockstoreConfigHelper.getConfig(url, "potato");
+        });
+        Assertions.assertEquals(ExceptionHandler.CLIENT_ERROR, exitCode);
     }
 }

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreConfigHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreConfigHelperTest.java
@@ -2,14 +2,12 @@ package io.dockstore.tooltester.helper;
 
 import java.io.IOException;
 
-import com.beust.jcommander.ParameterException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
-import static io.dockstore.tooltester.client.cli.Client.main;
-import static io.dockstore.tooltester.helper.ExceptionHandler.COMMAND_ERROR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.org.webcompere.systemstubs.SystemStubs.catchSystemExit;
 
 
@@ -24,28 +22,28 @@ public class DockstoreConfigHelperTest {
     public void testCwltoolConfig() {
         final String url = "https://staging.dockstore.org:8443";
         String cwltoolConfig = DockstoreConfigHelper.getConfig(url, "cwltool");
-        Assertions.assertEquals("token: test\\nserver-url: https://staging.dockstore.org:8443\\ncwlrunner: cwltool\n", cwltoolConfig);
+        assertEquals("token: test\\nserver-url: https://staging.dockstore.org:8443\\ncwlrunner: cwltool\n", cwltoolConfig);
     }
 
     @Test
     public void testToilConfig() throws IOException {
         final String url = "https://staging.dockstore.org:8443";
         String toilConfig = DockstoreConfigHelper.getConfig(url, "toil");
-        Assertions.assertEquals("token: test\\nserver-url: https://staging.dockstore.org:8443\\ncwlrunner: toil\n", toilConfig);
+        assertEquals("token: test\\nserver-url: https://staging.dockstore.org:8443\\ncwlrunner: toil\n", toilConfig);
     }
 
     @Test
     public void testCromwellConfig() throws IOException {
         final String url = "https://staging.dockstore.org:8443";
         String toilConfig = DockstoreConfigHelper.getConfig(url, "cromwell");
-        Assertions.assertEquals("token: test\\nserver-url: https://staging.dockstore.org:8443\\n# cromwell-version = 36\n", toilConfig);
+        assertEquals("token: test\\nserver-url: https://staging.dockstore.org:8443\\n# cromwell-version = 36\n", toilConfig);
     }
 
     @Test
     public void testCwlrunnerConfig() throws IOException {
         final String url = "https://staging.dockstore.org:8443";
         String toilConfig = DockstoreConfigHelper.getConfig(url, "cwl-runner");
-        Assertions.assertEquals("token: test\\nserver-url: https://staging.dockstore.org:8443\\ncwlrunner: cwl-runner\n", toilConfig);
+        assertEquals("token: test\\nserver-url: https://staging.dockstore.org:8443\\ncwlrunner: cwl-runner\n", toilConfig);
     }
 
     @Test
@@ -54,6 +52,6 @@ public class DockstoreConfigHelperTest {
         int exitCode = catchSystemExit(() -> {
             DockstoreConfigHelper.getConfig(url, "potato");
         });
-        Assertions.assertEquals(ExceptionHandler.CLIENT_ERROR, exitCode);
+        assertEquals(ExceptionHandler.CLIENT_ERROR, exitCode);
     }
 }

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreEntryHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreEntryHelperTest.java
@@ -11,9 +11,11 @@ import io.swagger.client.model.Tag;
 import io.swagger.client.model.Tool;
 import io.swagger.client.model.Workflow;
 import io.swagger.client.model.WorkflowVersion;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author gluu
@@ -45,7 +47,7 @@ public class DockstoreEntryHelperTest {
         Tag tag1 = tags.stream().filter(tag -> tag.getName().equals("1.0.4"))
                 .findFirst().get();
         String command = DockstoreEntryHelper.generateLaunchEntryCommand(dockstoreTool, tag1, "test.json");
-        Assertions.assertEquals(command, "dockstore tool launch --entry quay.io/briandoconnor/dockstore-tool-md5sum:1.0.4 --json test.json --script");
+        assertEquals(command, "dockstore tool launch --entry quay.io/briandoconnor/dockstore-tool-md5sum:1.0.4 --json test.json --script");
     }
 
     @Disabled
@@ -58,7 +60,7 @@ public class DockstoreEntryHelperTest {
         WorkflowVersion workflowVersion1 = workflowVersions.stream().filter(workflowVersion -> workflowVersion.getName().equals("1.4.0"))
                 .findFirst().get();
         String command = DockstoreEntryHelper.generateLaunchEntryCommand(publishedWorkflow, workflowVersion1, "test.json");
-        Assertions.assertEquals("dockstore workflow launch --entry github.com/briandoconnor/dockstore-workflow-md5sum:1.4.0 --json test.json --script", command);
+        assertEquals("dockstore workflow launch --entry github.com/briandoconnor/dockstore-workflow-md5sum:1.4.0 --json test.json --script", command);
         // With workflow name
         workflowId = 4818L;
         publishedWorkflow = workflowsApi.getPublishedWorkflow(workflowId, null);
@@ -66,7 +68,7 @@ public class DockstoreEntryHelperTest {
         workflowVersion1 = workflowVersions.stream().filter(workflowVersion -> workflowVersion.getName().equals("1.0.0"))
                 .findFirst().get();
         command = DockstoreEntryHelper.generateLaunchEntryCommand(publishedWorkflow, workflowVersion1, "test.yaml");
-        Assertions.assertEquals("dockstore workflow launch --entry github.com/ICGC-TCGA-PanCancer/pcawg-snv-indel-annotation:1.0.0 --yaml test.yaml --script", command);
+        assertEquals("dockstore workflow launch --entry github.com/ICGC-TCGA-PanCancer/pcawg-snv-indel-annotation:1.0.0 --yaml test.yaml --script", command);
     }
 
     @Test
@@ -74,7 +76,7 @@ public class DockstoreEntryHelperTest {
         Tool tool = new Tool();
         tool.setId("quay.io/briandoconnor/dockstore-tool-md5sum");
         DockstoreTool dockstoreTool = DockstoreEntryHelper.convertTRSToolToDockstoreEntry(tool, containersApi);
-        Assertions.assertNotNull(dockstoreTool);
+        assertNotNull(dockstoreTool);
     }
 
     @Disabled
@@ -83,18 +85,18 @@ public class DockstoreEntryHelperTest {
         Tool tool = new Tool();
         tool.setId("#workflow/github.com/briandoconnor/dockstore-workflow-md5sum");
         Workflow workflow = DockstoreEntryHelper.convertTRSToolToDockstoreEntry(tool, workflowsApi);
-        Assertions.assertNotNull(workflow);
+        assertNotNull(workflow);
     }
 
     @Test
     public void convertGitSSHUrlToGitHTTPSUrl() {
         String originalGitUrl = "git@github.com:briandoconnor/dockstore-workflow-md5sum.git";
-        Assertions.assertEquals("https://github.com/briandoconnor/dockstore-workflow-md5sum.git", DockstoreEntryHelper.convertGitSSHUrlToGitHTTPSUrl(originalGitUrl));
+        assertEquals("https://github.com/briandoconnor/dockstore-workflow-md5sum.git", DockstoreEntryHelper.convertGitSSHUrlToGitHTTPSUrl(originalGitUrl));
     }
     
     @Test
     public void convertDockstoreAbsolutePathToJenkinsRelativePath() {
         String dockstoreAbsolutePath = "/Dockerfile";
-        Assertions.assertEquals("Dockerfile", DockstoreEntryHelper.convertDockstoreAbsolutePathToJenkinsRelativePath(dockstoreAbsolutePath));
+        assertEquals("Dockerfile", DockstoreEntryHelper.convertDockstoreAbsolutePathToJenkinsRelativePath(dockstoreAbsolutePath));
     }
 }

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreEntryHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreEntryHelperTest.java
@@ -11,9 +11,9 @@ import io.swagger.client.model.Tag;
 import io.swagger.client.model.Tool;
 import io.swagger.client.model.Workflow;
 import io.swagger.client.model.WorkflowVersion;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author gluu
@@ -45,10 +45,10 @@ public class DockstoreEntryHelperTest {
         Tag tag1 = tags.stream().filter(tag -> tag.getName().equals("1.0.4"))
                 .findFirst().get();
         String command = DockstoreEntryHelper.generateLaunchEntryCommand(dockstoreTool, tag1, "test.json");
-        Assert.assertEquals(command, "dockstore tool launch --entry quay.io/briandoconnor/dockstore-tool-md5sum:1.0.4 --json test.json --script");
+        Assertions.assertEquals(command, "dockstore tool launch --entry quay.io/briandoconnor/dockstore-tool-md5sum:1.0.4 --json test.json --script");
     }
 
-    @Ignore
+    @Disabled
     @Test
     public void generateLaunchWorkflowCommand() {
         // No workflow name
@@ -58,7 +58,7 @@ public class DockstoreEntryHelperTest {
         WorkflowVersion workflowVersion1 = workflowVersions.stream().filter(workflowVersion -> workflowVersion.getName().equals("1.4.0"))
                 .findFirst().get();
         String command = DockstoreEntryHelper.generateLaunchEntryCommand(publishedWorkflow, workflowVersion1, "test.json");
-        Assert.assertEquals("dockstore workflow launch --entry github.com/briandoconnor/dockstore-workflow-md5sum:1.4.0 --json test.json --script", command);
+        Assertions.assertEquals("dockstore workflow launch --entry github.com/briandoconnor/dockstore-workflow-md5sum:1.4.0 --json test.json --script", command);
         // With workflow name
         workflowId = 4818L;
         publishedWorkflow = workflowsApi.getPublishedWorkflow(workflowId, null);
@@ -66,7 +66,7 @@ public class DockstoreEntryHelperTest {
         workflowVersion1 = workflowVersions.stream().filter(workflowVersion -> workflowVersion.getName().equals("1.0.0"))
                 .findFirst().get();
         command = DockstoreEntryHelper.generateLaunchEntryCommand(publishedWorkflow, workflowVersion1, "test.yaml");
-        Assert.assertEquals("dockstore workflow launch --entry github.com/ICGC-TCGA-PanCancer/pcawg-snv-indel-annotation:1.0.0 --yaml test.yaml --script", command);
+        Assertions.assertEquals("dockstore workflow launch --entry github.com/ICGC-TCGA-PanCancer/pcawg-snv-indel-annotation:1.0.0 --yaml test.yaml --script", command);
     }
 
     @Test
@@ -74,27 +74,27 @@ public class DockstoreEntryHelperTest {
         Tool tool = new Tool();
         tool.setId("quay.io/briandoconnor/dockstore-tool-md5sum");
         DockstoreTool dockstoreTool = DockstoreEntryHelper.convertTRSToolToDockstoreEntry(tool, containersApi);
-        Assert.assertNotNull(dockstoreTool);
+        Assertions.assertNotNull(dockstoreTool);
     }
 
-    @Ignore
+    @Disabled
     @Test
     public void convertTRSToolToWorkflow() {
         Tool tool = new Tool();
         tool.setId("#workflow/github.com/briandoconnor/dockstore-workflow-md5sum");
         Workflow workflow = DockstoreEntryHelper.convertTRSToolToDockstoreEntry(tool, workflowsApi);
-        Assert.assertNotNull(workflow);
+        Assertions.assertNotNull(workflow);
     }
 
     @Test
     public void convertGitSSHUrlToGitHTTPSUrl() {
         String originalGitUrl = "git@github.com:briandoconnor/dockstore-workflow-md5sum.git";
-        Assert.assertEquals("https://github.com/briandoconnor/dockstore-workflow-md5sum.git", DockstoreEntryHelper.convertGitSSHUrlToGitHTTPSUrl(originalGitUrl));
+        Assertions.assertEquals("https://github.com/briandoconnor/dockstore-workflow-md5sum.git", DockstoreEntryHelper.convertGitSSHUrlToGitHTTPSUrl(originalGitUrl));
     }
     
     @Test
     public void convertDockstoreAbsolutePathToJenkinsRelativePath() {
         String dockstoreAbsolutePath = "/Dockerfile";
-        Assert.assertEquals("Dockerfile", DockstoreEntryHelper.convertDockstoreAbsolutePathToJenkinsRelativePath(dockstoreAbsolutePath));
+        Assertions.assertEquals("Dockerfile", DockstoreEntryHelper.convertDockstoreAbsolutePathToJenkinsRelativePath(dockstoreAbsolutePath));
     }
 }

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/GA4GHHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/GA4GHHelperTest.java
@@ -15,8 +15,11 @@ import java.util.stream.Stream;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.client.model.Tool;
 import io.swagger.client.model.ToolVersion;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author gluu
@@ -27,15 +30,15 @@ public class GA4GHHelperTest {
 
     @Test
     public void runnerSupportsDescriptorType() {
-        Assertions.assertTrue(GA4GHHelper.runnerSupportsDescriptorType("cwl-runner", ToolVersion.DescriptorTypeEnum.CWL));
-        Assertions.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cwl-runner", ToolVersion.DescriptorTypeEnum.WDL));
-        Assertions.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cwl-runner", ToolVersion.DescriptorTypeEnum.NFL));
-        Assertions.assertTrue(GA4GHHelper.runnerSupportsDescriptorType("cwltool", ToolVersion.DescriptorTypeEnum.CWL));
-        Assertions.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cwltool", ToolVersion.DescriptorTypeEnum.WDL));
-        Assertions.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cwltool", ToolVersion.DescriptorTypeEnum.NFL));
-        Assertions.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cromwell", ToolVersion.DescriptorTypeEnum.CWL));
-        Assertions.assertTrue(GA4GHHelper.runnerSupportsDescriptorType("cromwell", ToolVersion.DescriptorTypeEnum.WDL));
-        Assertions.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cromwell", ToolVersion.DescriptorTypeEnum.NFL));
+        assertTrue(GA4GHHelper.runnerSupportsDescriptorType("cwl-runner", ToolVersion.DescriptorTypeEnum.CWL));
+        assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cwl-runner", ToolVersion.DescriptorTypeEnum.WDL));
+        assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cwl-runner", ToolVersion.DescriptorTypeEnum.NFL));
+        assertTrue(GA4GHHelper.runnerSupportsDescriptorType("cwltool", ToolVersion.DescriptorTypeEnum.CWL));
+        assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cwltool", ToolVersion.DescriptorTypeEnum.WDL));
+        assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cwltool", ToolVersion.DescriptorTypeEnum.NFL));
+        assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cromwell", ToolVersion.DescriptorTypeEnum.CWL));
+        assertTrue(GA4GHHelper.runnerSupportsDescriptorType("cromwell", ToolVersion.DescriptorTypeEnum.WDL));
+        assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cromwell", ToolVersion.DescriptorTypeEnum.NFL));
     }
 
     @Test
@@ -43,11 +46,11 @@ public class GA4GHHelperTest {
         String json = resourceFilePathToString();
         List<Tool> allTools = Arrays.asList(objectMapper.readValue(json, Tool[].class));
         List<Tool> filteredTools1 = GA4GHHelper.filterTools(allTools, false, new ArrayList<>(), new ArrayList<>(), true, true);
-        Assertions.assertEquals(25, filteredTools1.size());
+        assertEquals(25, filteredTools1.size());
         List<Tool> filteredTools2 = GA4GHHelper.filterTools(allTools, true, new ArrayList<>(), new ArrayList<>(), false, true);
-        Assertions.assertEquals(18, filteredTools2.size());
+        assertEquals(18, filteredTools2.size());
         List<Tool> filteredTools = GA4GHHelper.filterTools(allTools, true, new ArrayList<>(), new ArrayList<>(), true, true);
-        Assertions.assertEquals(20, filteredTools.size());
+        assertEquals(20, filteredTools.size());
     }
 
     private String resourceFilePathToString() throws IOException, URISyntaxException {

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/GA4GHHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/GA4GHHelperTest.java
@@ -13,12 +13,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import io.swagger.client.model.Tool;
 import io.swagger.client.model.ToolVersion;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author gluu
@@ -29,15 +27,15 @@ public class GA4GHHelperTest {
 
     @Test
     public void runnerSupportsDescriptorType() {
-        Assert.assertTrue(GA4GHHelper.runnerSupportsDescriptorType("cwl-runner", ToolVersion.DescriptorTypeEnum.CWL));
-        Assert.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cwl-runner", ToolVersion.DescriptorTypeEnum.WDL));
-        Assert.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cwl-runner", ToolVersion.DescriptorTypeEnum.NFL));
-        Assert.assertTrue(GA4GHHelper.runnerSupportsDescriptorType("cwltool", ToolVersion.DescriptorTypeEnum.CWL));
-        Assert.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cwltool", ToolVersion.DescriptorTypeEnum.WDL));
-        Assert.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cwltool", ToolVersion.DescriptorTypeEnum.NFL));
-        Assert.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cromwell", ToolVersion.DescriptorTypeEnum.CWL));
-        Assert.assertTrue(GA4GHHelper.runnerSupportsDescriptorType("cromwell", ToolVersion.DescriptorTypeEnum.WDL));
-        Assert.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cromwell", ToolVersion.DescriptorTypeEnum.NFL));
+        Assertions.assertTrue(GA4GHHelper.runnerSupportsDescriptorType("cwl-runner", ToolVersion.DescriptorTypeEnum.CWL));
+        Assertions.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cwl-runner", ToolVersion.DescriptorTypeEnum.WDL));
+        Assertions.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cwl-runner", ToolVersion.DescriptorTypeEnum.NFL));
+        Assertions.assertTrue(GA4GHHelper.runnerSupportsDescriptorType("cwltool", ToolVersion.DescriptorTypeEnum.CWL));
+        Assertions.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cwltool", ToolVersion.DescriptorTypeEnum.WDL));
+        Assertions.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cwltool", ToolVersion.DescriptorTypeEnum.NFL));
+        Assertions.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cromwell", ToolVersion.DescriptorTypeEnum.CWL));
+        Assertions.assertTrue(GA4GHHelper.runnerSupportsDescriptorType("cromwell", ToolVersion.DescriptorTypeEnum.WDL));
+        Assertions.assertFalse(GA4GHHelper.runnerSupportsDescriptorType("cromwell", ToolVersion.DescriptorTypeEnum.NFL));
     }
 
     @Test
@@ -45,11 +43,11 @@ public class GA4GHHelperTest {
         String json = resourceFilePathToString();
         List<Tool> allTools = Arrays.asList(objectMapper.readValue(json, Tool[].class));
         List<Tool> filteredTools1 = GA4GHHelper.filterTools(allTools, false, new ArrayList<>(), new ArrayList<>(), true, true);
-        Assert.assertEquals(25, filteredTools1.size());
+        Assertions.assertEquals(25, filteredTools1.size());
         List<Tool> filteredTools2 = GA4GHHelper.filterTools(allTools, true, new ArrayList<>(), new ArrayList<>(), false, true);
-        Assert.assertEquals(18, filteredTools2.size());
+        Assertions.assertEquals(18, filteredTools2.size());
         List<Tool> filteredTools = GA4GHHelper.filterTools(allTools, true, new ArrayList<>(), new ArrayList<>(), true, true);
-        Assert.assertEquals(20, filteredTools.size());
+        Assertions.assertEquals(20, filteredTools.size());
     }
 
     private String resourceFilePathToString() throws IOException, URISyntaxException {

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/TinyUrlTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/TinyUrlTest.java
@@ -1,8 +1,7 @@
 package io.dockstore.tooltester.helper;
 
-import org.junit.Test;
-
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author gluu
@@ -13,7 +12,7 @@ public class TinyUrlTest {
     public void getTinyUrl() throws Exception {
         String originalURL = "https://www.google.ca";
         String tinyUrl = TinyUrl.getTinyUrl(originalURL);
-        assertTrue(tinyUrl.equals("https://tinyurl.com/d4gfaxc") || tinyUrl.equals(originalURL));
+        Assertions.assertTrue(tinyUrl.equals("https://tinyurl.com/d4gfaxc") || tinyUrl.equals(originalURL));
     }
 
 }

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/TinyUrlTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/TinyUrlTest.java
@@ -1,7 +1,8 @@
 package io.dockstore.tooltester.helper;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author gluu
@@ -12,7 +13,7 @@ public class TinyUrlTest {
     public void getTinyUrl() throws Exception {
         String originalURL = "https://www.google.ca";
         String tinyUrl = TinyUrl.getTinyUrl(originalURL);
-        Assertions.assertTrue(tinyUrl.equals("https://tinyurl.com/d4gfaxc") || tinyUrl.equals(originalURL));
+        assertTrue(tinyUrl.equals("https://tinyurl.com/d4gfaxc") || tinyUrl.equals(originalURL));
     }
 
 }


### PR DESCRIPTION
**Description**
This PR upgrades `tooltester` from using `Junit 4` to using `Junit 5`. This PR is similar in nature to this [PR](https://github.com/dockstore/dockstore/pull/5297).

**Issue**
[SEAB-5177](https://ucsc-cgl.atlassian.net/browse/SEAB-5177)

[SEAB-5177]: https://ucsc-cgl.atlassian.net/browse/SEAB-5177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ