### PR TITLE
Added additional metrics to ToolTester

### DIFF
--- a/tooltester/src/main/java/io/dockstore/tooltester/runWorkflow/WorkflowRunner.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/runWorkflow/WorkflowRunner.java
@@ -65,6 +65,7 @@ import static io.dockstore.tooltester.helper.ExceptionHandler.COMMAND_ERROR;
 import static io.dockstore.tooltester.helper.ExceptionHandler.GENERIC_ERROR;
 import static io.dockstore.tooltester.helper.ExceptionHandler.errorMessage;
 import static io.dockstore.tooltester.helper.ExceptionHandler.exceptionMessage;
+import static java.lang.Math.min;
 import static java.util.UUID.randomUUID;
 import static org.apache.commons.lang3.math.NumberUtils.max;
 import static org.apache.commons.lang3.time.DurationFormatUtils.formatDuration;
@@ -479,9 +480,12 @@ public class WorkflowRunner {
         GetMetricStatisticsResponse response = cloudWatchClient.getMetricStatistics(request);
         Double sumOfDataPoints = 0D;
         Double maxDataPoint = 0D;
+        Double minDataPoint = 0D;
+        final int totalDataPoints = response.datapoints().size();
         for (Datapoint datapoint: response.datapoints()) {
             sumOfDataPoints += datapoint.average();
             maxDataPoint = max(maxDataPoint, datapoint.average());
+            minDataPoint = min(minDataPoint, datapoint.average());
             // datapoint.average() is not actually obtaining the average. This is because the ECS container is only
             // collecting metrics every minute, and we have asked for a minute by minute metric breakdown.
             // So, we are getting the only statistic collected for each minute.
@@ -489,6 +493,8 @@ public class WorkflowRunner {
         Double averageOfDataPoints = sumOfDataPoints / response.datapoints().size();
         runMetrics.putAdditionalPropertiesItem(metricName + "_AVERAGE", averageOfDataPoints);
         runMetrics.putAdditionalPropertiesItem(metricName + "_MAX", maxDataPoint);
+        runMetrics.putAdditionalPropertiesItem(metricName + "_MIN", minDataPoint);
+        runMetrics.putAdditionalPropertiesItem(metricName + "_NUMBER_OF_DATAPOINTS", totalDataPoints);
 
     }
 


### PR DESCRIPTION
**Description**
With this PR, for every metric that is gathered from CloudWatch, we will now upload the following information to QA. The average of all the data points, the maximum of the datapoints, the minimum of the datapoints and the total number of datapoints.

**ISSUE:**
This PR was created due to this [conversation](https://ucsc-cgl.atlassian.net/browse/SEAB-5179?focusedCommentId=44836) in this PR: [SEAB-5179](https://ucsc-cgl.atlassian.net/browse/SEAB-5179).

[SEAB-5179]: https://ucsc-cgl.atlassian.net/browse/SEAB-5179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ