### PR TITLE
Address metrics aggregator usability feedback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,12 +29,12 @@ workflows:
   version: 2
   everything:
     jobs:
-      - build:
+      - build-metrics-aggregator:
           <<: *common_filters
       - metrics-aggregator-tests:
           <<: *common_filters
           requires:
-            - build
+            - build-metrics-aggregator
 
 jobs:
   metrics-aggregator-tests:
@@ -46,7 +46,7 @@ jobs:
     steps:
       - setup_and_run_integration_tests
 
-  build:
+  build-metrics-aggregator:
     docker: # run the steps with Docker
       - image: cimg/openjdk:<< pipeline.parameters.java-tag >>
         environment:
@@ -58,7 +58,7 @@ jobs:
       - checkout # check out source code to working directory
       - install-git-secrets
       - run:
-          name: build
+          name: build-metrics-aggregator
           command: cd metricsaggregator && mvn -B clean install -DskipTests
 
         # Running scan must occur after build

--- a/metricsaggregator/README.md
+++ b/metricsaggregator/README.md
@@ -7,7 +7,7 @@ information to Dockstore.
 
 ### Configuration file
 
-Create a configuration file like the following:
+Create a configuration file like the following. A template `metrics-aggregator.config` file can be found [here](templates/metrics-aggregator.config).
 
 ```
 [dockstore]
@@ -20,13 +20,19 @@ endpointOverride: <Optional S3 endpoint override>
 ```
 **Required:**
 - `server-url`: The Dockstore server URL that's used to send API requests to.
+  - Examples:
+    - `https://qa.dockstore.org/api`
+    - `https://staging.dockstore.org/api`
+    - `https://dockstore.org/api`
 - `token`: The Dockstore token of a Dockstore user. This user must be an admin or curator in order to be able to post aggregated metrics to Dockstore.
 - `bucketName`: The S3 bucket name storing metrics data. This is the bucket that the metrics aggregator will go through in order
   to aggregate metrics.
 
 **Optional:**
 - `endpointOverride`: Endpoint override to use when creating the S3 clients. This is typically only used for local testing so that a LocalStack endpoint 
-override can be used.
+override can be used. Omit this key completely if you're running the metrics aggregator against non-local Dockstore environments like prod, staging, and QA. View the [template](templates/metrics-aggregator.config) for an example of a config file without this key.
+
+Note that if the configuration file path is not passed as an argument via `--config` or `-c`, then the default location is set to `./metrics-aggregator.config`. 
 
 ### AWS credentials
 
@@ -94,3 +100,5 @@ with miniwdl on DNAstack:
 java -jar target/metricsaggregator-*-SNAPSHOT.jar submit-validation-data --config my-custom-config \
 --data <path-to-my-data-file> --validator MINIWDL --validatorVersion 1.0 --platform DNA_STACK 
 ```
+
+After running this command, you will want to run the `aggregate-metrics` command to aggregate the new validation data submitted.

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/CommandLineArgs.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/CommandLineArgs.java
@@ -33,7 +33,7 @@ public class CommandLineArgs {
 
     @Parameters(commandNames = { "aggregate-metrics" }, commandDescription = "Aggregate metrics in S3")
     public static class AggregateMetricsCommand extends CommandLineArgs {
-        @Parameter(names = {"-c", "--config"}, description = "The config file path.", required = true)
+        @Parameter(names = {"-c", "--config"}, description = "The config file path.")
         private File config = new File("./" + MetricsAggregatorClient.CONFIG_FILE_NAME);
 
         public File getConfig() {

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/MetricsAggregatorClient.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/MetricsAggregatorClient.java
@@ -87,7 +87,7 @@ public class MetricsAggregatorClient {
             System.exit(FAILURE_EXIT_CODE);
         }
 
-        if (commandLineArgs.isHelp()) {
+        if (jCommander.getParsedCommand() == null || commandLineArgs.isHelp()) {
             jCommander.usage();
         } else if ("aggregate-metrics".equals(jCommander.getParsedCommand())) {
             if (aggregateMetricsCommand.isHelp()) {

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/MetricsAggregatorClient.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/MetricsAggregatorClient.java
@@ -181,7 +181,16 @@ public class MetricsAggregatorClient {
 
             String trsId = lineComponents[TRS_ID_INDEX];
             String versionName = lineComponents[VERSION_NAME_INDEX];
-            boolean isValid = Boolean.parseBoolean(lineComponents[IS_VALID_INDEX]);
+
+            // Parse boolean value for isValid column
+            String isValidValue = lineComponents[IS_VALID_INDEX];
+            boolean isValid;
+            if ("true".equalsIgnoreCase(isValidValue) || "false".equalsIgnoreCase(isValidValue)) {
+                isValid = Boolean.parseBoolean(isValidValue);
+            } else {
+                LOG.error("isValid column value '{}' is not a boolean value, skipping line '{}'", isValidValue, csvLine);
+                continue;
+            }
             String dateExecuted = lineComponents[DATE_EXECUTED_INDEX];
             ValidationExecution validationExecution = new ValidationExecution()
                     .validatorTool(validator)

--- a/metricsaggregator/src/test/java/io/dockstore/metricsaggregator/client/cli/MetricsAggregatorClientTest.java
+++ b/metricsaggregator/src/test/java/io/dockstore/metricsaggregator/client/cli/MetricsAggregatorClientTest.java
@@ -306,6 +306,7 @@ class MetricsAggregatorClientTest {
 
         String id = "#workflow/" + workflow.getFullWorkflowPath();
         String versionId = version.getName();
+        // This file contains 1 valid CSV line and 2 invalid CSV lines (one doesn't have all the required columns, and the other has a non-boolean value for the isValid column)
         String successfulDataFilePath = ResourceHelpers.resourceFilePath("miniwdl-successful-validation-workflow-names.csv");
 
         // Submit validation data using a data file that contains workflow names of workflows that were successfully validated with miniwdl on DNAstack

--- a/metricsaggregator/src/test/resources/miniwdl-successful-validation-workflow-names.csv
+++ b/metricsaggregator/src/test/resources/miniwdl-successful-validation-workflow-names.csv
@@ -1,3 +1,4 @@
 trsId,versionName,isValid,dateExecuted
-#workflow/github.com/garyluu/testWorkflow
 #workflow/github.com/garyluu/testWorkflow,master,true,2023-04-04T14:52:42Z
+#workflow/github.com/garyluu/testWorkflow
+#workflow/github.com/garyluu/testWorkflow,master,THIS_IS_NOT_A_BOOLEAN,2023-04-04T14:52:42Z

--- a/metricsaggregator/templates/metrics-aggregator.config
+++ b/metricsaggregator/templates/metrics-aggregator.config
@@ -1,0 +1,7 @@
+# This is a template metrics aggregator config file for QA. Modify it for different environments.
+[dockstore]
+server-url: https://qa.dockstore.org/api
+token: <Dockstore token>
+
+[s3]
+bucketName: qa-dockstore-metrics-data


### PR DESCRIPTION
**Description**
This PR addresses feedback from the metrics aggregator usability test ([doc](https://docs.google.com/document/d/1T-70yCWVGlerK7JsPiH1g5M9ozzlOYPkjdMAr4Loeik/edit#)).

Fixes:
- Checks that the `isValid` value in the CSV file is a proper boolean
- Make the `--config` argument optional (again). It was originally optional when I first created the aggregator but I must've made it required while testing something in a PR and it slipped passed me.
- Display usage if no commands are provided
- README updates:
  - Specified the default location of the metrics aggregator config file and created a template config file
  - Gave examples of the Dockstore server URL
- Updated the name of the build step in the CircleCI config to be more specific (build metrics aggregator)

**Review Instructions**
Verify that the issues stated in the usability doc are fixed.

**Issue**
[SEAB-5378](https://ucsc-cgl.atlassian.net/browse/SEAB-5378)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[SEAB-5378]: https://ucsc-cgl.atlassian.net/browse/SEAB-5378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ