### PR TITLE
Attach format dnastack script during maven build

### DIFF
--- a/metricsaggregator/pom.xml
+++ b/metricsaggregator/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>io.dockstore</groupId>
     <artifactId>metricsaggregator</artifactId>
-    <version>0.1-zeta.0-SNAPSHOT</version>
+    <version>0.1-alpha.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>metricsaggregator</name>

--- a/metricsaggregator/pom.xml
+++ b/metricsaggregator/pom.xml
@@ -212,28 +212,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>add_script</id>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>attach-artifact</goal>
-                            </goals>
-                            <configuration>
-                                <artifacts>
-                                    <artifact>
-                                        <file>scripts/format-dnastack-validation-data.sh</file>
-                                        <type>sh</type>
-                                        <classifier>dist</classifier>
-                                    </artifact>
-                                </artifacts>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>3.1.2</version>
@@ -389,7 +367,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>1.12</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>io.swagger</groupId>
@@ -577,6 +555,28 @@
                         <goals>
                             <goal>verify</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add_script</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>scripts/format-dnastack-validation-data.sh</file>
+                                    <type>sh</type>
+                                    <classifier>dist</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/metricsaggregator/pom.xml
+++ b/metricsaggregator/pom.xml
@@ -212,6 +212,28 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>add_script</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>attach-artifact</goal>
+                            </goals>
+                            <configuration>
+                                <artifacts>
+                                    <artifact>
+                                        <file>scripts/format-dnastack-validation-data.sh</file>
+                                        <type>sh</type>
+                                        <classifier>dist</classifier>
+                                    </artifact>
+                                </artifacts>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>3.1.2</version>
@@ -368,24 +390,6 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>1.12</version>
-                    <executions>
-                        <execution>
-                            <id>add_script</id>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>attach-artifact</goal>
-                            </goals>
-                            <configuration>
-                                <artifacts>
-                                    <artifact>
-                                        <file>scripts/format-dnastack-validation-data.sh</file>
-                                        <type>sh</type>
-                                        <classifier>dist</classifier>
-                                    </artifact>
-                                </artifacts>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>io.swagger</groupId>

--- a/metricsaggregator/pom.xml
+++ b/metricsaggregator/pom.xml
@@ -572,7 +572,7 @@
                             <artifacts>
                                 <artifact>
                                     <file>scripts/format-dnastack-validation-data.sh</file>
-                                    <type>sh</type>
+                                    <type>format-dnastack-validation-data.sh</type>
                                     <classifier>dist</classifier>
                                 </artifact>
                             </artifacts>

--- a/metricsaggregator/pom.xml
+++ b/metricsaggregator/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>io.dockstore</groupId>
     <artifactId>metricsaggregator</artifactId>
-    <version>0.1-alpha.0-SNAPSHOT</version>
+    <version>0.1-zeta.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>metricsaggregator</name>
@@ -368,6 +368,24 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>1.12</version>
+                    <executions>
+                        <execution>
+                            <id>add_script</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>attach-artifact</goal>
+                            </goals>
+                            <configuration>
+                                <artifacts>
+                                    <artifact>
+                                        <file>scripts/format-dnastack-validation-data.sh</file>
+                                        <type>format-dnastack-validation-data.sh</type>
+                                        <classifier>dist</classifier>
+                                    </artifact>
+                                </artifacts>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>io.swagger</groupId>

--- a/metricsaggregator/pom.xml
+++ b/metricsaggregator/pom.xml
@@ -379,7 +379,7 @@
                                 <artifacts>
                                     <artifact>
                                         <file>scripts/format-dnastack-validation-data.sh</file>
-                                        <type>format-dnastack-validation-data.sh</type>
+                                        <type>sh</type>
                                         <classifier>dist</classifier>
                                     </artifact>
                                 </artifacts>


### PR DESCRIPTION
**Description**
This PR attaches the format dnastack script as an artifact, which will come into play when I do a maven release to deploy the metrics aggregator to artifactory. This is done so the deployer can get these artifacts from artifactory.

**Review Instructions**
Go to the metrics-aggregator folder in [artifactory](https://artifacts.oicr.on.ca/artifactory/webapp/#/artifacts/browse/tree/General/collab-release/io/dockstore/metricsaggregator) and verify that the latest release has the metrics aggregator JAR and the format-dnastack-validation-data script.

**Issue**
[SEAB-5423](https://ucsc-cgl.atlassian.net/browse/SEAB-5423)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[SEAB-5423]: https://ucsc-cgl.atlassian.net/browse/SEAB-5423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ