### PR TITLE
SEAB-5700: set dateExecuted field for RunExecution

### DIFF
--- a/tooltester/src/main/java/io/dockstore/tooltester/runWorkflow/WorkflowRunner.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/runWorkflow/WorkflowRunner.java
@@ -488,6 +488,7 @@ public class WorkflowRunner {
         if (getTotalWallClockTimeInISO861Standard() != null) {
             runMetrics.setExecutionTime(getTotalWallClockTimeInISO861Standard());
         }
+        runMetrics.setDateExecuted(workflowStartTime.toString());
         addDataFromSingleMetric("CpuUtilized");
         addDataFromSingleMetric("MemoryUtilized");
 

--- a/tooltester/src/main/java/io/dockstore/tooltester/runWorkflow/WorkflowRunner.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/runWorkflow/WorkflowRunner.java
@@ -487,8 +487,8 @@ public class WorkflowRunner {
         runMetrics.setExecutionStatus(getExecutionStatus());
         if (getTotalWallClockTimeInISO861Standard() != null) {
             runMetrics.setExecutionTime(getTotalWallClockTimeInISO861Standard());
+            runMetrics.setDateExecuted(workflowStartTime.toInstant().toString());
         }
-        runMetrics.setDateExecuted(workflowStartTime.toString());
         addDataFromSingleMetric("CpuUtilized");
         addDataFromSingleMetric("MemoryUtilized");
 


### PR DESCRIPTION
**Description**
This PR adds the `dateExecuted` information for the tooltester to upload.

**Review Instructions**
Review that the `dateExecuted` field in RunExecuted is correctly set.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5700

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
