### PR TITLE
Update ubuntu-2204 image tag to fix test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
 
   machine_integration_test_exec:
     machine: # run the steps with Ubuntu VM
-      image: default
+      image: ubuntu-2204:2024.01.1
     environment:
       PGHOST: 127.0.0.1
     resource_class: medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
 
   machine_integration_test_exec:
     machine: # run the steps with Ubuntu VM
-      image: ubuntu-2204:2022.10.1
+      image: default
     environment:
       PGHOST: 127.0.0.1
     resource_class: medium


### PR DESCRIPTION
**Description**
The CircleCI tests for the release branch failed because it couldn't install the postgres client: https://app.circleci.com/pipelines/github/dockstore/dockstore-support/334/workflows/094af9f0-3e56-42ac-84cc-d2966f2739df/jobs/1010.

The CircleCI UI showed that the job was using a deprecated image, so I updated the image to a newer one and that fixed the issue.

**Review Instructions**
Builds should pass

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
