### PR TITLE
Add prototype for aggregating metrics with AWS Athena

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 417 third-party dependencies.
+Lists of 421 third-party dependencies.
      (The Apache Software License, Version 2.0) Adapter: RxJava 2 (com.squareup.retrofit2:adapter-rxjava2:2.9.0 - https://github.com/square/retrofit)
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.13:2.5.32 - https://akka.io/)
@@ -66,6 +66,7 @@ Lists of 417 third-party dependencies.
      (Apache License, Version 2.0) AWS Java SDK :: Profiles (software.amazon.awssdk:profiles:2.17.186 - https://aws.amazon.com/sdkforjava)
      (Apache License, Version 2.0) AWS Java SDK :: Regions (software.amazon.awssdk:regions:2.17.186 - https://aws.amazon.com/sdkforjava/core/regions)
      (Apache License, Version 2.0) AWS Java SDK :: SDK Core (software.amazon.awssdk:sdk-core:2.17.186 - https://aws.amazon.com/sdkforjava)
+     (Apache License, Version 2.0) AWS Java SDK :: Services :: Amazon Athena (software.amazon.awssdk:athena:2.17.186 - https://aws.amazon.com/sdkforjava)
      (Apache License, Version 2.0) AWS Java SDK :: Services :: Amazon CloudWatch (software.amazon.awssdk:cloudwatch:2.17.186 - https://aws.amazon.com/sdkforjava)
      (Apache License, Version 2.0) AWS Java SDK :: Services :: Amazon EC2 Container Service (software.amazon.awssdk:ecs:2.17.186 - https://aws.amazon.com/sdkforjava)
      (Apache License, Version 2.0) AWS Java SDK :: Services :: Amazon Kinesis (software.amazon.awssdk:kinesis:2.17.186 - https://aws.amazon.com/sdkforjava)
@@ -284,6 +285,7 @@ Lists of 417 third-party dependencies.
      (The Apache Software License, Version 2.0) jnr-unixsocket (com.github.jnr:jnr-unixsocket:0.18 - http://github.com/jnr/jnr-unixsocket)
      (MIT License) jnr-x86asm (com.github.jnr:jnr-x86asm:1.0.2 - http://github.com/jnr/jnr-x86asm)
      (Apache License, Version 2.0) Joda-Time (joda-time:joda-time:2.12.5 - https://www.joda.org/joda-time/)
+     (Apache License, Version 2.0) jOOQ (org.jooq:jooq:3.19.7 - http://www.jooq.org/jooq)
      (The MIT License) JOpt Simple (net.sf.jopt-simple:jopt-simple:5.0.3 - http://pholser.github.io/jopt-simple)
      (Public Domain) JSON in Java (org.json:json:20231013 - https://github.com/douglascrockford/JSON-java)
      (Revised BSD License) JSONLD Java :: Core (com.github.jsonld-java:jsonld-java:0.8.3 - http://github.com/jsonld-java/jsonld-java/jsonld-java/)
@@ -366,6 +368,7 @@ Lists of 417 third-party dependencies.
      (BSD-2-Clause) PostgreSQL JDBC Driver (org.postgresql:postgresql:42.7.2 - https://jdbc.postgresql.org)
      (MIT) pprint_2.13 (com.lihaoyi:pprint_2.13:0.7.3 - https://github.com/lihaoyi/PPrint)
      (The Apache Software License, Version 2.0) rank-eval (org.elasticsearch.plugin:rank-eval-client:7.10.2 - https://github.com/elastic/elasticsearch)
+     (Apache License 2.0) Reactive Relational Database Connectivity - SPI (io.r2dbc:r2dbc-spi:1.0.0.RELEASE - https://r2dbc.io/r2dbc-spi)
      (CC0) reactive-streams (org.reactivestreams:reactive-streams:1.0.3 - http://www.reactive-streams.org/)
      (MIT) refined (eu.timepit:refined_2.13:0.10.1 - https://github.com/fthomas/refined)
      (The Apache Software License, Version 2.0) rest (org.elasticsearch.client:elasticsearch-rest-client:7.10.2 - https://github.com/elastic/elasticsearch)
@@ -412,6 +415,7 @@ Lists of 417 third-party dependencies.
      (Apache License, Version 2.0) tomcat-juli (org.apache.tomcat:tomcat-juli:10.1.13 - https://tomcat.apache.org/)
      (GNU General Public License (GPLv3)) toolbackup (io.dockstore:toolbackup:1.16.0-SNAPSHOT - https://github.com/dockstore/dockstore-support)
      (GNU General Public License (GPLv3)) tooltester (io.dockstore:tooltester:1.16.0-SNAPSHOT - https://github.com/dockstore/dockstore-support)
+     (GNU General Public License (GPLv3)) topicgenerator (io.dockstore:topicgenerator:1.16.0-SNAPSHOT - https://github.com/dockstore/dockstore-support)
      (Eclipse Distribution License - v 1.0) TXW2 Runtime (org.glassfish.jaxb:txw2:3.0.2 - https://eclipse-ee4j.github.io/jaxb-ri/)
      (GNU General Public License (GPLv3)) utils (io.dockstore:utils:1.16.0-SNAPSHOT - https://github.com/dockstore/dockstore-support)
      (WDL License https://github.com/openwdl/wdl/blob/master/LICENSE) wdl-biscayne (org.broadinstitute:wdl-biscayne_2.13:85 - no url defined)

--- a/metricsaggregator/pom.xml
+++ b/metricsaggregator/pom.xml
@@ -145,6 +145,14 @@
             <artifactId>s3</artifactId>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>athena</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.javamoney.moneta</groupId>
             <artifactId>moneta-core</artifactId>
         </dependency>
@@ -172,6 +180,11 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.el</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jooq</groupId>
+            <artifactId>jooq</artifactId>
+            <version>3.19.7</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -313,6 +326,7 @@
                                 <usedDependency>jakarta.validation:jakarta.validation-api</usedDependency>
                                 <usedDependency>org.hibernate:hibernate-validator</usedDependency>
                                 <usedDependency>org.glassfish:jakarta.el</usedDependency>
+                                <usedDependency>software.amazon.awssdk:auth</usedDependency>
                             </usedDependencies>
                         </configuration>
                     </execution>

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/MetricsAggregatorAthenaClient.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/MetricsAggregatorAthenaClient.java
@@ -149,9 +149,9 @@ public class MetricsAggregatorAthenaClient {
                     "projection.version.type" = "injected",
                     "projection.platform.type" = "enum",
                     "projection.platform.values" = "%s",
-                    "storage.location.template" = "s3://qa-dockstore-metrics-data/${entity}/${registry}/${org}/${name}/${version}/${platform}/"
+                    "storage.location.template" = "s3://%s/${entity}/${registry}/${org}/${name}/${version}/${platform}/"
                 )
-                """, tableName, metricsBucketName, entityProjectionValues, registryProjectionValues, platformProjectionValues);
+                """, tableName, metricsBucketName, entityProjectionValues, registryProjectionValues, platformProjectionValues, metricsBucketName);
         executeQuery(query);
         return tableName;
     }

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/MetricsAggregatorAthenaClient.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/MetricsAggregatorAthenaClient.java
@@ -1,0 +1,342 @@
+package io.dockstore.metricsaggregator;
+
+import static io.dockstore.metricsaggregator.helper.AthenaClientHelper.createAthenaClient;
+import static io.dockstore.utils.DockstoreApiClientUtils.setupApiClient;
+
+import io.dockstore.common.Partner;
+import io.dockstore.metricsaggregator.MetricsAggregatorS3Client.S3DirectoryInfo;
+import io.dockstore.metricsaggregator.helper.AthenaClientHelper;
+import io.dockstore.metricsaggregator.helper.ExecutionStatusAthenaAggregator;
+import io.dockstore.openapi.client.api.ExtendedGa4GhApi;
+import io.dockstore.openapi.client.api.MetadataApi;
+import io.dockstore.openapi.client.model.EntryTypeMetadata;
+import io.dockstore.openapi.client.model.ExecutionStatusMetric;
+import io.dockstore.openapi.client.model.Metrics;
+import io.dockstore.openapi.client.model.RegistryBean;
+import io.dockstore.openapi.client.model.SourceControlBean;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.athena.AthenaClient;
+import software.amazon.awssdk.services.athena.model.ColumnInfo;
+import software.amazon.awssdk.services.athena.model.Datum;
+import software.amazon.awssdk.services.athena.model.GetQueryResultsResponse;
+import software.amazon.awssdk.services.athena.model.Row;
+import software.amazon.awssdk.services.athena.paginators.GetQueryResultsIterable;
+
+/**
+ * A class that aggregates metrics using AWS Athena.
+ */
+public class MetricsAggregatorAthenaClient {
+    private static final Logger LOG = LoggerFactory.getLogger(MetricsAggregatorAthenaClient.class);
+    private final ExecutionStatusAthenaAggregator executionStatusAggregator = new ExecutionStatusAthenaAggregator();
+
+    private final String database;
+    private final String outputS3Bucket;
+    private final AthenaClient athenaClient;
+    private final MetadataApi metadataApi;
+
+    public MetricsAggregatorAthenaClient(MetricsAggregatorConfig config) throws URISyntaxException {
+        this.database = config.getAthenaConfig().database();
+        this.outputS3Bucket = config.getAthenaConfig().outputS3Bucket();
+        this.athenaClient = createAthenaClient();
+        this.metadataApi = new MetadataApi(setupApiClient(config.getDockstoreConfig().serverUrl())); // Anonymous client
+    }
+
+    /**
+     * Aggregate metrics using AWS Athena for the list of S3 directories and posts them to Dockstore.
+     * @param s3DirectoriesToAggregate
+     * @param extendedGa4GhApi
+     * @param skipPostingToDockstore
+     */
+    public void aggregateMetrics(List<S3DirectoryInfo> s3DirectoriesToAggregate, ExtendedGa4GhApi extendedGa4GhApi, boolean skipPostingToDockstore) {
+        String tableName = createTable(); // Create table if it doesn't exist
+        // Aggregate metrics for each directory
+        s3DirectoriesToAggregate.stream().parallel().forEach(s3DirectoryInfo -> {
+            Map<String, Metrics> platformToMetrics = getAggregatedMetricsForPlatforms(tableName, s3DirectoryInfo);
+            platformToMetrics.forEach((platform, metrics) -> {
+                LOG.info("Tool ID: {}, version {}, platform: {}\n{}", s3DirectoryInfo.toolId(), s3DirectoryInfo.versionId(), platform, metrics);
+                if (!skipPostingToDockstore) {
+                    // TODO: Allow posting to webservice when the Athena prototype is complete
+                    extendedGa4GhApi.aggregatedMetricsPut(metrics, platform, s3DirectoryInfo.toolId(), s3DirectoryInfo.versionId());
+                }
+            });
+        });
+    }
+
+    /**
+     * Create a table with a JSON schema and projected partitions, which removes the need to manually manage partitions.
+     * @return
+     */
+    public String createTable() {
+        final String tableName = "qa_metrics_prototype";
+        LOG.info("Creating table: {}", tableName);
+        final String entityProjectionValues = String.join(",", metadataApi.getEntryTypeMetadataList()
+                .stream()
+                .map(EntryTypeMetadata::getTerm)
+                .toList());
+        final String registryProjectionValues = Stream.concat(
+                    metadataApi.getSourceControlList().stream().map(SourceControlBean::getValue),
+                    metadataApi.getDockerRegistries().stream().map(RegistryBean::getDockerPath))
+                .collect(Collectors.joining(","));
+        final String platformProjectionValues = String.join(",", Arrays.stream(Partner.values()).map(Partner::name).toList());
+        final String query = String.format("""
+                CREATE EXTERNAL TABLE IF NOT EXISTS %s (
+                    runexecutions array<struct<
+                        executionid:string,
+                        dateexecuted:string,
+                        executionstatus:string,
+                        executiontime:string,
+                        memoryrequirementsgb:double,
+                        cpurequirements:int,
+                        cost:struct<value:double,currency:string>,
+                        region:string,
+                        additionalproperties:string
+                        >
+                    >,
+                    taskexecutions array<struct<
+                        executionid:string,
+                        taskexecutions:array<struct<
+                            executionid:string,
+                            dateexecuted:string,
+                            executionstatus:string,
+                            executiontime:string,
+                            memoryrequirements:double,
+                            cpurequirements:int,
+                            cost:struct<value:double,currency:string>,
+                            region:string,
+                            additionalproperties:string
+                            >
+                        >
+                    >>,
+                    validationexecutions array<struct<
+                        executionid:string,
+                        dateexecuted:string,
+                        validatortool:string,
+                        validatortoolversion:string,
+                        isvalid:boolean,
+                        errormessage:string,
+                        additionalproperties:string
+                        >
+                    >
+                )
+                PARTITIONED BY (
+                    `entity` string,
+                    `registry` string,
+                    `org` string,
+                    `name` string,
+                    `version` string,
+                    `platform` string
+                )
+                ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
+                LOCATION 's3://qa-dockstore-metrics-data/'
+                TBLPROPERTIES (
+                    "projection.enabled" = "true",
+                    "projection.entity.type" = "enum",
+                    "projection.entity.values" = "%s",
+                    "projection.registry.type" = "enum",
+                    "projection.registry.values" = "%s",
+                    "projection.org.type" = "injected",
+                    "projection.name.type" = "injected",
+                    "projection.version.type" = "injected",
+                    "projection.platform.type" = "enum",
+                    "projection.platform.values" = "%s",
+                    "storage.location.template" = "s3://qa-dockstore-metrics-data/${entity}/${registry}/${org}/${name}/${version}/${platform}/"
+                )
+                """, tableName, entityProjectionValues, registryProjectionValues, platformProjectionValues);
+        executeQuery(query);
+        return tableName;
+    }
+
+    /**
+     * Creates a view for the runExecutions array.
+     * @param entity
+     * @param registry
+     * @param org
+     * @param name
+     * @param version
+     * @return
+     * @throws InterruptedException
+     */
+    public String createRunExecutionsView(String tableName, String entity, String registry, String org, String name, String version) throws InterruptedException {
+        final String viewName = createViewName(entity, registry, org, name, version, "runexecutions");
+        LOG.info("Creating runexecutions view: {}", viewName);
+        final String query = String.format("""
+                CREATE OR REPLACE VIEW "%s" AS
+                WITH dataset AS (
+                    SELECT platform, runexecutions
+                    FROM %s
+                    WHERE entity = '%s' AND registry = '%s' AND org = '%s' AND name = '%s' AND version = '%s'
+                )
+                SELECT platform, unnested.executionid, unnested.dateexecuted, unnested.executionstatus, unnested.executiontime, unnested.memoryrequirementsgb, unnested.cpurequirements, unnested.cost, unnested.region
+                FROM dataset, UNNEST(dataset.runexecutions) AS t(unnested);
+                """, viewName, tableName, entity, registry, org, name, version);
+        executeQuery(query);
+        return viewName;
+    }
+
+    public String createRunExecutionsView(String tableName, S3DirectoryInfo s3DirectoryInfo) throws InterruptedException {
+        return createRunExecutionsView(tableName, s3DirectoryInfo.entityPartition(), s3DirectoryInfo.registryPartition(), s3DirectoryInfo.orgPartition(), s3DirectoryInfo.namePartition(), s3DirectoryInfo.versionPartition());
+    }
+
+    public String createTaskExecutionsView(String entity, String registry, String org, String name, String version) {
+        final String viewName = String.join("/", entity, registry, org, name, version, "taskexecutions");
+        executeQuery(String.format("""
+            CREATE OR REPLACE VIEW '%s' AS
+            WITH dataset AS (
+                SELECT platform, taskexecutions
+                FROM kathys_projected_metrics
+                WHERE entity = '%s' AND registry = '%s' AND org = '%s' AND name = '%s' AND version = '%s'
+            )
+            SELECT platform, unnested.taskexecutions
+            FROM dataset, UNNEST(dataset.taskexecutions) AS t(unnested);
+            """, viewName, entity, registry, org, name, version));
+        return viewName;
+    }
+
+    public String createValidationExecutionsView(String entity, String registry, String org, String name, String version) {
+        final String viewName = createViewName(entity, registry, org, name, version, "validationexecutions");
+        LOG.info("Creating validationexecutions view: {}", viewName);
+        final String query = String.format("""
+                CREATE OR REPLACE VIEW "%s" AS
+                WITH dataset AS (
+                    SELECT platform, validationexecutions
+                    FROM kathys_projected_metrics
+                    WHERE entity = '%s' AND registry = '%s' AND org = '%s' AND name = '%s' AND version = '%s'
+                )
+                SELECT platform, unnested.executionid, unnested.dateexecuted, unnested.validatortool, unnested.validatortoolversion, unnested.isvalid, unnested.errormessage
+                FROM dataset, UNNEST(dataset.validationexecutions) AS t(unnested);
+                """, viewName, entity, registry, org, name, version);
+        executeQuery(query);
+        return viewName;
+    }
+
+    /**
+     * Creates a view name. These view names will need to be enclosed with double quotes in queries because the entry components may contain special characters like dashes.
+     * @param entity
+     * @param registry
+     * @param org
+     * @param name
+     * @param version
+     * @param viewType
+     * @return
+     */
+    public String createViewName(String entity, String registry, String org, String name, String version, String viewType) {
+        return String.join("_", entity, registry, org, name, version, viewType);
+    }
+
+    public void dropView(String viewName) {
+        final String query = String.format("""
+                DROP VIEW "%s";
+                """, viewName);
+        executeQuery(query);
+    }
+
+    /**
+     * Executes the query using AWS Athena and returns a list of QueryResultRow
+     * @param query
+     * @return
+     */
+    public List<QueryResultRow> executeQuery(String query) {
+        List<QueryResultRow> queryResultRows = new ArrayList<>();
+
+        LOG.info("Running SQL query: {}", query);
+        Optional<GetQueryResultsIterable> getQueryResultsIterable = AthenaClientHelper.executeQuery(athenaClient, database, outputS3Bucket, query);
+        if (getQueryResultsIterable.isPresent()) {
+            Map<String, Integer> columnNameToColumnIndex = new HashMap<>();
+
+            for (GetQueryResultsResponse result : getQueryResultsIterable.get()) {
+                // Create a map of column name to column value index. Only needs to be created once because the other pages should have the same columns
+                if (columnNameToColumnIndex.isEmpty()) {
+                    List<ColumnInfo> columnInfoList = result.resultSet().resultSetMetadata().columnInfo();
+                    for (int i = 0; i < columnInfoList.size(); ++i) {
+                        ColumnInfo columnInfo = columnInfoList.get(i);
+                        columnNameToColumnIndex.put(columnInfo.name(), i);
+                    }
+                }
+
+                // Get the row values as a list of strings
+                List<Row> rows = result.resultSet().rows();
+                if (rows.size() > 1) {
+                    for (Row row : rows.subList(1, rows.size())) { // Ignore first row because it contains column headers
+                        List<Datum> rowData = row.data();
+                        List<String> columnValues = rowData.stream()
+                                .map(Datum::varCharValue) // Note: the column value can be null if there's no value for it
+                                .toList();
+                        queryResultRows.add(new QueryResultRow(columnNameToColumnIndex, columnValues));
+                    }
+                }
+            }
+        }
+
+        return queryResultRows;
+    }
+
+    /**
+     * Calculate aggregated metrics for all platforms in the S3 directory.
+     * @param tableName
+     * @param s3DirectoryInfo
+     * @return
+     */
+    public Map<String, Metrics> getAggregatedMetricsForPlatforms(String tableName, S3DirectoryInfo s3DirectoryInfo) {
+        Map<String, Metrics> platformToMetrics = new HashMap<>();
+        // Calculate metrics for runexecutions
+        // TODO: Calculate metrics for taskexecutions and validationexecutions
+        String runExecutionsView = "";
+        try {
+            runExecutionsView = createRunExecutionsView(tableName, s3DirectoryInfo);
+        } catch (InterruptedException e) {
+            LOG.error("Could not create runexecutions view");
+        }
+
+        try {
+            if (!runExecutionsView.isEmpty()) {
+                LOG.info("Aggregating workflow executions");
+                String query = executionStatusAggregator.createQuery(runExecutionsView);
+                Map<String, ExecutionStatusMetric> platformToExecutionStatusMetric = executionStatusAggregator.createMetricByPlatform(
+                        executeQuery(query));
+                platformToExecutionStatusMetric.forEach((platform, executionStatusMetric) -> {
+                    if (platformToMetrics.containsKey(platform)) {
+                        platformToMetrics.get(platform).executionStatusCount(executionStatusMetric);
+                    } else {
+                        platformToMetrics.put(platform, new Metrics().executionStatusCount(executionStatusMetric));
+                    }
+                    LOG.info("Aggregated metrics for tool ID {}, version {}, platform {} from directory {}", s3DirectoryInfo.toolId(),
+                            s3DirectoryInfo.versionId(), platform, s3DirectoryInfo.versionS3KeyPrefix());
+                });
+            }
+        } catch (Exception e) {
+            LOG.error("Could not aggregate metrics for tool ID {}, version {}", s3DirectoryInfo.toolId(), s3DirectoryInfo.versionId(), e);
+        } finally {
+            // Delete views
+            dropView(runExecutionsView);
+        }
+
+        return platformToMetrics;
+    }
+
+    /**
+     * A record that contains information about a single row of results from an Athena query execution.
+     * @param columnNameToColumnIndex Map of column names to column index to be used with the columnValues list.
+     * @param columnValues List of column values.
+     */
+    public record QueryResultRow(Map<String, Integer> columnNameToColumnIndex, List<String> columnValues) {
+        /**
+         * Get the column value that corresponds with the column name.
+         * @param columnName
+         * @return
+         */
+        public Optional<String> getColumnValue(String columnName) {
+            Integer columnIndex = columnNameToColumnIndex.get(columnName);
+            return columnIndex == null || columnValues.get(columnIndex) == null ? Optional.empty() : Optional.of(columnValues.get(columnIndex));
+        }
+    }
+}

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/MetricsAggregatorConfig.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/MetricsAggregatorConfig.java
@@ -22,53 +22,38 @@ import org.apache.commons.configuration2.INIConfiguration;
 import org.apache.commons.configuration2.SubnodeConfiguration;
 
 public class MetricsAggregatorConfig {
-
-    private String dockstoreServerUrl;
-    private String dockstoreToken;
-    private String s3Bucket;
-    private String s3EndpointOverride;
-
-    public MetricsAggregatorConfig() {
-    }
+    private DockstoreConfig dockstoreConfig;
+    private S3Config s3Config;
+    private AthenaConfig athenaConfig;
 
     public MetricsAggregatorConfig(INIConfiguration config) {
         SubnodeConfiguration dockstoreSection = ConfigFileUtils.getDockstoreSection(config);
         SubnodeConfiguration s3Section = config.getSection("s3");
-        this.dockstoreServerUrl = dockstoreSection.getString("server-url", "http://localhost:8080");
-        this.dockstoreToken = dockstoreSection.getString("token");
-        this.s3Bucket = s3Section.getString("bucketName", "local-dockstore-metrics-data");
-        this.s3EndpointOverride = s3Section.getString("endpointOverride");
+        SubnodeConfiguration athenaSection = config.getSection("athena");
+
+        this.dockstoreConfig = new DockstoreConfig(dockstoreSection.getString("server-url", "http://localhost:8080"), dockstoreSection.getString("token"));
+        this.s3Config = new S3Config(s3Section.getString("bucketName", "local-dockstore-metrics-data"), s3Section.getString("endpointOverride"));
+        this.athenaConfig = new AthenaConfig(athenaSection.getString("database"), athenaSection.getString("outputS3Bucket"));
     }
 
-    public String getDockstoreServerUrl() {
-        return dockstoreServerUrl;
+    public DockstoreConfig getDockstoreConfig() {
+        return dockstoreConfig;
     }
 
-    public void setDockstoreServerUrl(String dockstoreServerUrl) {
-        this.dockstoreServerUrl = dockstoreServerUrl;
+    public S3Config getS3Config() {
+        return s3Config;
     }
 
-    public String getDockstoreToken() {
-        return dockstoreToken;
+    public AthenaConfig getAthenaConfig() {
+        return athenaConfig;
     }
 
-    public void setDockstoreToken(String dockstoreToken) {
-        this.dockstoreToken = dockstoreToken;
+    public record DockstoreConfig(String serverUrl, String token) {
     }
 
-    public String getS3Bucket() {
-        return s3Bucket;
+    public record S3Config(String bucket, String endpointOverride) {
     }
 
-    public void setS3Bucket(String s3Bucket) {
-        this.s3Bucket = s3Bucket;
-    }
-
-    public String getS3EndpointOverride() {
-        return s3EndpointOverride;
-    }
-
-    public void setS3EndpointOverride(String s3Endpoint) {
-        this.s3EndpointOverride = s3Endpoint;
+    public record AthenaConfig(String database, String outputS3Bucket) {
     }
 }

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/MetricsAggregatorS3Client.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/MetricsAggregatorS3Client.java
@@ -29,6 +29,7 @@ import io.dockstore.common.metrics.MetricsDataS3Client;
 import io.dockstore.common.metrics.RunExecution;
 import io.dockstore.common.metrics.TaskExecutions;
 import io.dockstore.common.metrics.ValidationExecution;
+import io.dockstore.metricsaggregator.MetricsAggregatorAthenaClient.AthenaTablePartition;
 import io.dockstore.openapi.client.api.ExtendedGa4GhApi;
 import io.dockstore.openapi.client.model.Metrics;
 import java.io.IOException;
@@ -270,7 +271,8 @@ public class MetricsAggregatorS3Client {
                 String orgPartition = S3ClientHelper.getElementFromKey(prefix, 2);
                 String namePartition = S3ClientHelper.getElementFromKey(prefix, 3);
                 String versionPartition = S3ClientHelper.getElementFromKey(prefix, 4);
-                s3DirectoryInfos.add(new S3DirectoryInfo(toolId, versionId, platforms, prefix, entityPartition, registryPartition, orgPartition, namePartition, versionPartition));
+                AthenaTablePartition athenaTablePartition = new AthenaTablePartition(entityPartition, registryPartition, orgPartition, namePartition, versionPartition);
+                s3DirectoryInfos.add(new S3DirectoryInfo(toolId, versionId, platforms, prefix, athenaTablePartition));
             } else {
                 commonPrefixesToProcess.addAll(listObjectsV2Response.commonPrefixes());
             }
@@ -290,6 +292,6 @@ public class MetricsAggregatorS3Client {
         return getDirectories(s3KeyPrefix);
     }
 
-    public record S3DirectoryInfo(String toolId, String versionId, List<String> platforms, String versionS3KeyPrefix, String entityPartition, String registryPartition, String orgPartition, String namePartition, String versionPartition) {
+    public record S3DirectoryInfo(String toolId, String versionId, List<String> platforms, String versionS3KeyPrefix, AthenaTablePartition athenaTablePartition) {
     }
 }

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/CommandLineArgs.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/CommandLineArgs.java
@@ -36,8 +36,46 @@ public class CommandLineArgs {
         @Parameter(names = {"-c", "--config"}, description = "The config file path.")
         private File config = new File("./" + MetricsAggregatorClient.CONFIG_FILE_NAME);
 
+        @Parameter(names = {"--athena"}, description = "Aggregate metrics in S3 using AWS Athena")
+        private boolean withAthena = false;
+
+        @Parameter(names = {"--skipDockstore"}, description = "Skip posting the metrics to Dockstore")
+        private boolean skipDockstore = false;
+
+        @Parameter(names = {"--trsId"}, description = "Aggregate metrics for the tool specified by the TRS ID")
+        private String trsId;
+
         public File getConfig() {
             return config;
+        }
+
+        public boolean isWithAthena() {
+            return withAthena;
+        }
+
+        public boolean isSkipDockstore() {
+            return skipDockstore;
+        }
+
+        public String getTrsId() {
+            return trsId;
+        }
+    }
+
+    @Parameters(commandNames = { "execute-athena-query" }, commandDescription = "Execute an AWS athena query")
+    public static class ExecuteAthenaQuery extends CommandLineArgs {
+        @Parameter(names = { "-c", "--config" }, description = "The config file path.")
+        private File config = new File("./" + MetricsAggregatorClient.CONFIG_FILE_NAME);
+
+        @Parameter(names = { "-q", "--query" }, description = "The query to execute")
+        private String athenaQuery;
+
+        public File getConfig() {
+            return config;
+        }
+
+        public String getAthenaQuery() {
+            return athenaQuery;
         }
     }
 

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/CommandLineArgs.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/CommandLineArgs.java
@@ -62,23 +62,6 @@ public class CommandLineArgs {
         }
     }
 
-    @Parameters(commandNames = { "execute-athena-query" }, commandDescription = "Execute an AWS athena query")
-    public static class ExecuteAthenaQuery extends CommandLineArgs {
-        @Parameter(names = { "-c", "--config" }, description = "The config file path.")
-        private File config = new File("./" + MetricsAggregatorClient.CONFIG_FILE_NAME);
-
-        @Parameter(names = { "-q", "--query" }, description = "The query to execute")
-        private String athenaQuery;
-
-        public File getConfig() {
-            return config;
-        }
-
-        public String getAthenaQuery() {
-            return athenaQuery;
-        }
-    }
-
     @Parameters(commandNames = { "submit-validation-data" }, commandDescription = "Formats workflow validation data specified in a file then submits it to Dockstore")
     public static class SubmitValidationData extends CommandLineArgs {
         @Parameter(names = {"-c", "--config"}, description = "The config file path.")

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/CommandLineArgs.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/CommandLineArgs.java
@@ -22,6 +22,7 @@ import com.beust.jcommander.Parameters;
 import io.dockstore.common.Partner;
 import io.dockstore.openapi.client.model.ValidationExecution.ValidatorToolEnum;
 import java.io.File;
+import java.util.List;
 
 public class CommandLineArgs {
     @Parameter(names = "--help", description = "Prints help for metricsaggregator", help = true)
@@ -42,8 +43,8 @@ public class CommandLineArgs {
         @Parameter(names = {"--skipDockstore"}, description = "Skip posting the metrics to Dockstore")
         private boolean skipDockstore = false;
 
-        @Parameter(names = {"--trsId"}, description = "Aggregate metrics for the tool specified by the TRS ID")
-        private String trsId;
+        @Parameter(names = {"--trsIds"}, description = "Aggregate metrics for the tools specified TRS ID")
+        private List<String> trsIds;
 
         public File getConfig() {
             return config;
@@ -57,8 +58,8 @@ public class CommandLineArgs {
             return skipDockstore;
         }
 
-        public String getTrsId() {
-            return trsId;
+        public List<String> getTrsIds() {
+            return trsIds;
         }
     }
 

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/MetricsAggregatorClient.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/MetricsAggregatorClient.java
@@ -31,7 +31,6 @@ import io.dockstore.metricsaggregator.MetricsAggregatorConfig;
 import io.dockstore.metricsaggregator.MetricsAggregatorS3Client;
 import io.dockstore.metricsaggregator.MetricsAggregatorS3Client.S3DirectoryInfo;
 import io.dockstore.metricsaggregator.client.cli.CommandLineArgs.AggregateMetricsCommand;
-import io.dockstore.metricsaggregator.client.cli.CommandLineArgs.ExecuteAthenaQuery;
 import io.dockstore.metricsaggregator.client.cli.CommandLineArgs.SubmitTerraMetrics;
 import io.dockstore.metricsaggregator.client.cli.CommandLineArgs.SubmitValidationData;
 import io.dockstore.openapi.client.ApiClient;
@@ -74,12 +73,10 @@ public class MetricsAggregatorClient {
         final AggregateMetricsCommand aggregateMetricsCommand = new AggregateMetricsCommand();
         final SubmitValidationData submitValidationData = new SubmitValidationData();
         final SubmitTerraMetrics submitTerraMetrics = new SubmitTerraMetrics();
-        final ExecuteAthenaQuery executeAthenaQuery = new ExecuteAthenaQuery();
 
         jCommander.addCommand(aggregateMetricsCommand);
         jCommander.addCommand(submitValidationData);
         jCommander.addCommand(submitTerraMetrics);
-        jCommander.addCommand(executeAthenaQuery);
 
         try {
             jCommander.parse(args);
@@ -110,14 +107,6 @@ public class MetricsAggregatorClient {
                 } catch (Exception e) {
                     exceptionMessage(e, "Could not aggregate metrics", GENERIC_ERROR);
                 }
-            }
-        } else if ("execute-athena-query".equals(jCommander.getParsedCommand())) {
-            if (executeAthenaQuery.isHelp()) {
-                jCommander.usage();
-            } else {
-                INIConfiguration config = getConfiguration(executeAthenaQuery.getConfig());
-                final MetricsAggregatorConfig metricsAggregatorConfig = new MetricsAggregatorConfig(config);
-                metricsAggregatorClient.executeAthenaQuery(metricsAggregatorConfig, executeAthenaQuery.getAthenaQuery());
             }
         } else if ("submit-validation-data".equals(jCommander.getParsedCommand())) {
             if (submitValidationData.isHelp()) {
@@ -182,15 +171,6 @@ public class MetricsAggregatorClient {
             metricsAggregatorAthenaClient.aggregateMetrics(s3DirectoriesToAggregate, extendedGa4GhApi, skipPostingToDockstore);
         } else {
             metricsAggregatorS3Client.aggregateMetrics(s3DirectoriesToAggregate, extendedGa4GhApi, skipPostingToDockstore);
-        }
-    }
-
-    private void executeAthenaQuery(MetricsAggregatorConfig config, String query) {
-        try {
-            MetricsAggregatorAthenaClient metricsAggregatorAthenaClient = new MetricsAggregatorAthenaClient(config);
-            metricsAggregatorAthenaClient.executeQuery(query);
-        } catch (URISyntaxException e) {
-            exceptionMessage(e, "Could not create AWS Athena client", GENERIC_ERROR);
         }
     }
 

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/MetricsAggregatorClient.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/MetricsAggregatorClient.java
@@ -168,7 +168,7 @@ public class MetricsAggregatorClient {
 
         if (aggregateMetricsCommand.isWithAthena()) {
             MetricsAggregatorAthenaClient metricsAggregatorAthenaClient = new MetricsAggregatorAthenaClient(config);
-            metricsAggregatorAthenaClient.aggregateMetrics(s3DirectoriesToAggregate, extendedGa4GhApi, skipPostingToDockstore);
+            metricsAggregatorAthenaClient.aggregateMetrics(config.getS3Config().bucket(), s3DirectoriesToAggregate, extendedGa4GhApi, skipPostingToDockstore);
         } else {
             metricsAggregatorS3Client.aggregateMetrics(s3DirectoriesToAggregate, extendedGa4GhApi, skipPostingToDockstore);
         }

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/TerraMetricsSubmitter.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/client/cli/TerraMetricsSubmitter.java
@@ -82,7 +82,7 @@ public class TerraMetricsSubmitter {
     }
 
     public void submitTerraMetrics() {
-        ApiClient apiClient = setupApiClient(config.getDockstoreServerUrl(), config.getDockstoreToken());
+        ApiClient apiClient = setupApiClient(config.getDockstoreConfig().serverUrl(), config.getDockstoreConfig().token());
         ExtendedGa4GhApi extendedGa4GhApi = new ExtendedGa4GhApi(apiClient);
         WorkflowsApi workflowsApi = new WorkflowsApi(apiClient);
 

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/AthenaAggregator.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/AthenaAggregator.java
@@ -1,0 +1,166 @@
+package io.dockstore.metricsaggregator.helper;
+
+import static org.jooq.impl.DSL.avg;
+import static org.jooq.impl.DSL.coalesce;
+import static org.jooq.impl.DSL.count;
+import static org.jooq.impl.DSL.cube;
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.inline;
+import static org.jooq.impl.DSL.max;
+import static org.jooq.impl.DSL.min;
+import static org.jooq.impl.DSL.table;
+
+import io.dockstore.common.Partner;
+import io.dockstore.metricsaggregator.MetricsAggregatorAthenaClient.QueryResultRow;
+import io.dockstore.openapi.client.model.Metric;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.jooq.Field;
+import org.jooq.SQLDialect;
+import org.jooq.SelectField;
+import org.jooq.conf.Settings;
+import org.jooq.impl.DSL;
+
+/**
+ * An abstract class that helps create SQL statements to aggregate metrics that are executed by AWS Athena.
+ * Utilizes the JOOQ library to construct dynamic SQL statements.
+ */
+public abstract class AthenaAggregator<M extends Metric> {
+    public static final String PLATFORM_COLUMN_NAME = "platform";
+    private static final Field<?> PLATFORM_FIELD = field(PLATFORM_COLUMN_NAME);
+    // Fields for the SELECT clause
+    private final Set<SelectField<?>> selectFields = new HashSet<>();
+    // Fields for the GROUP BY clause
+    private final Set<Field<?>> groupFields = new HashSet<>();
+
+    protected AthenaAggregator() {
+        // All queries will be grouped by platform at a minimum
+        selectFields.add(coalesce(PLATFORM_FIELD, inline(Partner.ALL.name())).as(PLATFORM_COLUMN_NAME)); // Coalesce null platform values to "ALL"
+        groupFields.add(PLATFORM_FIELD);
+    }
+
+    /**
+     * Get the column name containing the metric.
+     * Athena columns are lowercase, but if a non-lowercase column is provided (ex: camelCase), Athena automatically lowercases it.
+     * @return
+     */
+    public abstract String getMetricColumnName();
+
+    /**
+     * Create a metric from a single query result row.
+     * @param queryResultRow
+     * @return
+     */
+    public abstract Optional<M> createMetricFromQueryResultRow(QueryResultRow queryResultRow);
+
+    public Set<SelectField<?>> getSelectFields() {
+        return this.selectFields;
+    }
+
+    public void addSelectFields(Set<SelectField<?>> newSelectFields) {
+        this.selectFields.addAll(newSelectFields);
+    }
+
+    public Set<Field<?>> getGroupFields() {
+        return this.groupFields;
+    }
+
+    public void addGroupFields(Set<Field<?>> newGroupFields) {
+        this.groupFields.addAll(newGroupFields);
+    }
+
+    /**
+     * Create the query string using the SELECT and GROUP BY fields.
+     * @param runExecutionsView
+     * @return
+     */
+    public String createQuery(String runExecutionsView) {
+        return DSL.using(SQLDialect.DEFAULT, new Settings().withRenderFormatted(true))
+                .select(this.selectFields)
+                .from(table(String.format("\"%s\"", runExecutionsView))) // Need to quote the view name because it can contain special characters
+                .groupBy(cube(this.groupFields.toArray(Field[]::new))) // CUBE generates sub-totals for all combinations of the GROUP BY columns.
+                .getSQL();
+    }
+
+    /**
+     * Given a list of query result rows, creates a metric for each row and maps it to a platform
+     * @param queryResultRows
+     * @return
+     */
+    public Map<String, M> createMetricByPlatform(List<QueryResultRow> queryResultRows) {
+        Map<String, M> metricByPlatform = new HashMap<>();
+        queryResultRows.forEach(queryResultRow -> {
+            Optional<String> platform = getPlatformFromQueryResultRow(queryResultRow);
+            if (platform.isPresent()) {
+                Optional<M> metric = createMetricFromQueryResultRow(queryResultRow);
+                metric.ifPresent(m -> metricByPlatform.put(platform.get(), m));
+            }
+        });
+        return metricByPlatform;
+    }
+
+    /**
+     * Returns a set of statistical SELECT fields: min, avg, max, count
+     *
+     * @return
+     */
+    public Set<SelectField<?>> getStatisticSelectFields() {
+        return Set.of(min(field(getMetricColumnName())).as(getMinColumnName()),
+                avg(field(getMetricColumnName(), Double.class)).as(getAvgColumnName()),
+                max(field(getMetricColumnName())).as(getMaxColumnName()),
+                count(field(getMetricColumnName())).as(getCountColumnName()));
+    }
+
+    /**
+     * Get the platform column value from the query result row
+     * @param queryResultRow
+     * @return
+     */
+    public Optional<String> getPlatformFromQueryResultRow(QueryResultRow queryResultRow) {
+        return queryResultRow.getColumnValue(PLATFORM_COLUMN_NAME);
+    }
+
+    public String substitutePeriodsForUnderscores(String columnName) {
+        return columnName.replace(".", "_");
+    }
+
+    public String getMinColumnName() {
+        return "min_" + substitutePeriodsForUnderscores(getMetricColumnName());
+    }
+
+    public String getAvgColumnName() {
+        return "avg_" + substitutePeriodsForUnderscores(getMetricColumnName());
+    }
+
+    public String getMaxColumnName() {
+        return "max_" + substitutePeriodsForUnderscores(getMetricColumnName());
+    }
+
+    public String getCountColumnName() {
+        return "count_" + substitutePeriodsForUnderscores(getMetricColumnName());
+    }
+
+    public Optional<Double> getMinColumnValue(QueryResultRow queryResultRow) {
+        return queryResultRow.getColumnValue(getMinColumnName()).map(Double::valueOf);
+    }
+
+    public Optional<Double> getAvgColumnValue(QueryResultRow queryResultRow) {
+        return queryResultRow.getColumnValue(getAvgColumnName()).map(Double::valueOf);
+    }
+
+    public Optional<Double> getMaxColumnValue(QueryResultRow queryResultRow) {
+        return queryResultRow.getColumnValue(getMaxColumnName()).map(Double::valueOf);
+    }
+
+    public Optional<Integer> getCountColumnValue(QueryResultRow queryResultRow) {
+        Optional<Integer> countColumnValue = queryResultRow.getColumnValue(getCountColumnName()).map(Integer::valueOf);
+        if (countColumnValue.isPresent() && countColumnValue.get() == 0) { // There were 0 non-null column values
+            return Optional.empty();
+        }
+        return countColumnValue;
+    }
+}

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/AthenaClientHelper.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/AthenaClientHelper.java
@@ -1,0 +1,125 @@
+package io.dockstore.metricsaggregator.helper;
+
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.services.athena.AthenaClient;
+import software.amazon.awssdk.services.athena.model.AthenaException;
+import software.amazon.awssdk.services.athena.model.GetQueryExecutionRequest;
+import software.amazon.awssdk.services.athena.model.GetQueryExecutionResponse;
+import software.amazon.awssdk.services.athena.model.GetQueryResultsRequest;
+import software.amazon.awssdk.services.athena.model.QueryExecutionContext;
+import software.amazon.awssdk.services.athena.model.QueryExecutionState;
+import software.amazon.awssdk.services.athena.model.ResultConfiguration;
+import software.amazon.awssdk.services.athena.model.StartQueryExecutionRequest;
+import software.amazon.awssdk.services.athena.model.StartQueryExecutionResponse;
+import software.amazon.awssdk.services.athena.paginators.GetQueryResultsIterable;
+
+/**
+ * A helper class for executing queries with the AthenaClient.
+ */
+public final class AthenaClientHelper {
+    public static final long SLEEP_AMOUNT_IN_MS = 500;
+
+    private static final Logger LOG = LoggerFactory.getLogger(AthenaClientHelper.class);
+
+    private AthenaClientHelper() {
+    }
+
+    public static AthenaClient createAthenaClient() {
+        return AthenaClient.builder().credentialsProvider(DefaultCredentialsProvider.create()).build();
+    }
+
+    /**
+     * Executes an Athena query and returns GetQueryResultsIterable containing the query results
+     * @param athenaClient
+     * @param athenaDatabase
+     * @param athenaOutputS3Bucket
+     * @param query
+     * @return
+     * @throws InterruptedException
+     */
+    public static Optional<GetQueryResultsIterable> executeQuery(AthenaClient athenaClient, String athenaDatabase, String athenaOutputS3Bucket, String query) {
+        try {
+            String queryExecutionId = submitAthenaQuery(athenaClient, athenaDatabase, athenaOutputS3Bucket, query);
+            waitForQueryToComplete(athenaClient, queryExecutionId);
+            return Optional.of(getQueryResults(athenaClient, queryExecutionId));
+        } catch (Exception e) {
+            LOG.error("Could not execute AWS Athena query", e);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Submits a query to Amazon Athena and returns the execution ID of the query.
+     * @param athenaClient
+     * @param athenaDatabase
+     * @param athenaOutputS3Bucket
+     * @param query
+     * @return Athena query execution ID
+     */
+    public static String submitAthenaQuery(AthenaClient athenaClient, String athenaDatabase, String athenaOutputS3Bucket, String query) {
+        try {
+            // The QueryExecutionContext allows us to set the database.
+            QueryExecutionContext queryExecutionContext = QueryExecutionContext.builder()
+                    .database(athenaDatabase)
+                    .build();
+
+            // The result configuration specifies where the results of the query should go.
+            ResultConfiguration resultConfiguration = ResultConfiguration.builder()
+                    .outputLocation(athenaOutputS3Bucket)
+                    .build();
+
+            StartQueryExecutionRequest startQueryExecutionRequest = StartQueryExecutionRequest.builder()
+                    .queryString(query)
+                    .queryExecutionContext(queryExecutionContext)
+                    .resultConfiguration(resultConfiguration)
+                    .build();
+
+            StartQueryExecutionResponse startQueryExecutionResponse = athenaClient.startQueryExecution(startQueryExecutionRequest);
+            return startQueryExecutionResponse.queryExecutionId();
+        } catch (AthenaException e) {
+            LOG.error("Could not submit AWS Athena query", e);
+        }
+        return "";
+    }
+
+    /**
+     * Wait for an Amazon Athena query to complete, fail or to be cancelled.
+     * @param athenaClient
+     * @param queryExecutionId
+     * @throws InterruptedException
+     */
+    public static void waitForQueryToComplete(AthenaClient athenaClient, String queryExecutionId) throws InterruptedException {
+        GetQueryExecutionRequest getQueryExecutionRequest = GetQueryExecutionRequest.builder()
+                .queryExecutionId(queryExecutionId)
+                .build();
+
+        GetQueryExecutionResponse getQueryExecutionResponse;
+        boolean isQueryStillRunning = true;
+        while (isQueryStillRunning) {
+            getQueryExecutionResponse = athenaClient.getQueryExecution(getQueryExecutionRequest);
+            String queryState = getQueryExecutionResponse.queryExecution().status().state().toString();
+            if (queryState.equals(QueryExecutionState.FAILED.toString())) {
+                throw new RuntimeException(
+                        "The Amazon Athena query failed to run with error message: " + getQueryExecutionResponse
+                                .queryExecution().status().stateChangeReason());
+            } else if (queryState.equals(QueryExecutionState.CANCELLED.toString())) {
+                throw new RuntimeException("The Amazon Athena query was cancelled.");
+            } else if (queryState.equals(QueryExecutionState.SUCCEEDED.toString())) {
+                isQueryStillRunning = false;
+            } else {
+                // Sleep an amount of time before retrying again.
+                Thread.sleep(SLEEP_AMOUNT_IN_MS);
+            }
+        }
+    }
+
+    public static GetQueryResultsIterable getQueryResults(AthenaClient athenaClient, String queryExecutionId) {
+        GetQueryResultsRequest getQueryResultsRequest = GetQueryResultsRequest.builder()
+                .queryExecutionId(queryExecutionId)
+                .build();
+        return athenaClient.getQueryResultsPaginator(getQueryResultsRequest);
+    }
+}

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/CostAthenaAggregator.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/CostAthenaAggregator.java
@@ -1,0 +1,36 @@
+package io.dockstore.metricsaggregator.helper;
+
+import io.dockstore.metricsaggregator.MetricsAggregatorAthenaClient.QueryResultRow;
+import io.dockstore.openapi.client.model.CostMetric;
+import java.util.Optional;
+
+/**
+ * Aggregate cost metrics by calculating the min, average, max, and number of data points using AWS Athena.
+ */
+public class CostAthenaAggregator extends AthenaAggregator<CostMetric> {
+    public CostAthenaAggregator() {
+        super();
+        this.addSelectFields(getStatisticSelectFields());
+    }
+
+    @Override
+    public String getMetricColumnName() {
+        return "cost.value";
+    }
+
+    @Override
+    public Optional<CostMetric> createMetricFromQueryResultRow(QueryResultRow queryResultRow) {
+        Optional<Double> min = getMinColumnValue(queryResultRow);
+        Optional<Double> avg = getAvgColumnValue(queryResultRow);
+        Optional<Double> max = getMaxColumnValue(queryResultRow);
+        Optional<Integer> numberOfDataPoints = getCountColumnValue(queryResultRow);
+        if (min.isPresent() && avg.isPresent() && max.isPresent() && numberOfDataPoints.isPresent()) {
+            return Optional.of(new CostMetric()
+                    .minimum(min.get())
+                    .average(avg.get())
+                    .maximum(max.get())
+                    .numberOfDataPointsForAverage(numberOfDataPoints.get()));
+        }
+        return Optional.empty();
+    }
+}

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/CpuAthenaAggregator.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/CpuAthenaAggregator.java
@@ -1,0 +1,36 @@
+package io.dockstore.metricsaggregator.helper;
+
+import io.dockstore.metricsaggregator.MetricsAggregatorAthenaClient.QueryResultRow;
+import io.dockstore.openapi.client.model.CpuMetric;
+import java.util.Optional;
+
+/**
+ * Aggregate CPU metrics by calculating the min, average, max, and number of data points using AWS Athena.
+ */
+public class CpuAthenaAggregator extends AthenaAggregator<CpuMetric> {
+    public CpuAthenaAggregator() {
+        super();
+        this.addSelectFields(getStatisticSelectFields());
+    }
+
+    @Override
+    public String getMetricColumnName() {
+        return "cpurequirements";
+    }
+
+    @Override
+    public Optional<CpuMetric> createMetricFromQueryResultRow(QueryResultRow queryResultRow) {
+        Optional<Double> min = getMinColumnValue(queryResultRow);
+        Optional<Double> avg = getAvgColumnValue(queryResultRow);
+        Optional<Double> max = getMaxColumnValue(queryResultRow);
+        Optional<Integer> numberOfDataPoints = getCountColumnValue(queryResultRow);
+        if (min.isPresent() && avg.isPresent() && max.isPresent() && numberOfDataPoints.isPresent()) {
+            return Optional.of(new CpuMetric()
+                    .minimum(min.get())
+                    .average(avg.get())
+                    .maximum(max.get())
+                    .numberOfDataPointsForAverage(numberOfDataPoints.get()));
+        }
+        return Optional.empty();
+    }
+}

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/ExecutionStatusAthenaAggregator.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/ExecutionStatusAthenaAggregator.java
@@ -1,0 +1,91 @@
+package io.dockstore.metricsaggregator.helper;
+
+import static java.util.stream.Collectors.groupingBy;
+import static org.jooq.impl.DSL.coalesce;
+import static org.jooq.impl.DSL.count;
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.inline;
+
+import io.dockstore.common.metrics.ExecutionStatus;
+import io.dockstore.metricsaggregator.MetricsAggregatorAthenaClient.QueryResultRow;
+import io.dockstore.openapi.client.model.ExecutionStatusMetric;
+import io.dockstore.openapi.client.model.MetricsByStatus;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.jooq.Field;
+import org.jooq.SelectField;
+
+public class ExecutionStatusAthenaAggregator extends AthenaAggregator<ExecutionStatusMetric> {
+    // Aggregators used to calculate metrics by execution status
+    private final ExecutionTimeAthenaAggregator executionTimeAggregator = new ExecutionTimeAthenaAggregator();
+    private final CpuAthenaAggregator cpuAggregator = new CpuAthenaAggregator();
+    private final MemoryAthenaAggregator memoryAggregator = new MemoryAthenaAggregator();
+    private final CostAthenaAggregator costAggregator = new CostAthenaAggregator();
+
+    public ExecutionStatusAthenaAggregator() {
+        super();
+        Field<?> executionStatusField = field(getMetricColumnName());
+        Set<SelectField<?>> selectFields = new HashSet<>();
+        selectFields.add(coalesce(executionStatusField, inline(ExecutionStatus.ALL.name())).as(getMetricColumnName()));
+        selectFields.add(count(executionStatusField).as(getCountColumnName()));
+        selectFields.addAll(cpuAggregator.getSelectFields());
+        selectFields.addAll(memoryAggregator.getSelectFields());
+        selectFields.addAll(costAggregator.getSelectFields());
+        this.addSelectFields(selectFields);
+        this.addGroupFields(Set.of(executionStatusField)); // Group by status
+    }
+
+    @Override
+    public String getMetricColumnName() {
+        return "executionstatus";
+    }
+
+    @Override
+    public Optional<ExecutionStatusMetric> createMetricFromQueryResultRow(QueryResultRow queryResultRow) {
+        Optional<String> executionStatus = queryResultRow.getColumnValue(getMetricColumnName());
+        Optional<Integer> executionStatusCount = getCountColumnValue(queryResultRow);
+        if (executionStatus.isEmpty() || executionStatusCount.isEmpty()) {
+            return Optional.empty();
+        }
+
+        MetricsByStatus metricsByStatus = new MetricsByStatus().executionStatusCount(executionStatusCount.get());
+        cpuAggregator.createMetricFromQueryResultRow(queryResultRow).ifPresent(metricsByStatus::setCpu);
+        memoryAggregator.createMetricFromQueryResultRow(queryResultRow).ifPresent(metricsByStatus::setMemory);
+        costAggregator.createMetricFromQueryResultRow(queryResultRow).ifPresent(metricsByStatus::setCost);
+        executionTimeAggregator.createMetricFromQueryResultRow(queryResultRow).ifPresent(metricsByStatus::setExecutionTime);
+        ExecutionStatusMetric executionStatusMetric = new ExecutionStatusMetric();
+        executionStatusMetric.getCount().put(executionStatus.get(), metricsByStatus);
+        return Optional.of(executionStatusMetric);
+    }
+
+    @Override
+    public Map<String, ExecutionStatusMetric> createMetricByPlatform(List<QueryResultRow> queryResultRows) {
+        Map<String, ExecutionStatusMetric> metricsByPlatform = new HashMap<>();
+        // Group query results by platform
+        Map<String, List<QueryResultRow>> queryResultRowsByPlatform = queryResultRows.stream()
+                .filter(row -> getPlatformFromQueryResultRow(row).isPresent())
+                .collect(groupingBy(row -> getPlatformFromQueryResultRow(row).get()));
+
+        // For each platform, create a metric
+        queryResultRowsByPlatform.forEach((platform, queryResultRowsForPlatform) -> {
+            Map<String, MetricsByStatus> executionStatusToMetricsByStatus = new HashMap<>();
+
+            queryResultRowsForPlatform.forEach(queryResultRow -> {
+                // For each row, create an execution status metric for the single status in the row
+                Optional<String> executionStatus = queryResultRow.getColumnValue(getMetricColumnName());
+                Optional<ExecutionStatusMetric> executionStatusMetric = createMetricFromQueryResultRow(queryResultRow);
+                if (executionStatus.isPresent() && executionStatusMetric.isPresent()) {
+                    // Get the MetricsByStatus for the row's execution status from the metric
+                    executionStatusToMetricsByStatus.put(executionStatus.get(), executionStatusMetric.get().getCount().get(executionStatus.get()));
+                }
+            });
+            metricsByPlatform.put(platform, new ExecutionStatusMetric().count(executionStatusToMetricsByStatus));
+        });
+
+        return metricsByPlatform;
+    }
+}

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/ExecutionTimeAthenaAggregator.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/ExecutionTimeAthenaAggregator.java
@@ -1,0 +1,22 @@
+package io.dockstore.metricsaggregator.helper;
+
+import io.dockstore.metricsaggregator.MetricsAggregatorAthenaClient.QueryResultRow;
+import io.dockstore.openapi.client.model.ExecutionTimeMetric;
+import java.util.Optional;
+
+/**
+ * Aggregate execution time metrics by calculating the min, average, max, and number of data points using AWS Athena.
+ * TODO: Implement the executiontime aggregator. Dockstore records executiontime metrics as an ISO-8601 duration which does not translate well in SQL and Athena. We may need to re-evalute how we record this metric.
+ */
+public class ExecutionTimeAthenaAggregator extends AthenaAggregator<ExecutionTimeMetric> {
+
+    @Override
+    public String getMetricColumnName() {
+        return "executiontime";
+    }
+
+    @Override
+    public Optional<ExecutionTimeMetric> createMetricFromQueryResultRow(QueryResultRow queryResultRow) {
+        return Optional.empty();
+    }
+}

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/MemoryAthenaAggregator.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/MemoryAthenaAggregator.java
@@ -1,0 +1,36 @@
+package io.dockstore.metricsaggregator.helper;
+
+import io.dockstore.metricsaggregator.MetricsAggregatorAthenaClient.QueryResultRow;
+import io.dockstore.openapi.client.model.MemoryMetric;
+import java.util.Optional;
+
+/**
+ * Aggregate memory metrics by calculating the min, average, max, and number of data points using AWS Athena.
+ */
+public class MemoryAthenaAggregator extends AthenaAggregator<MemoryMetric> {
+    public MemoryAthenaAggregator() {
+        super();
+        this.addSelectFields(getStatisticSelectFields());
+    }
+
+    @Override
+    public String getMetricColumnName() {
+        return "memoryrequirementsgb";
+    }
+
+    @Override
+    public Optional<MemoryMetric> createMetricFromQueryResultRow(QueryResultRow queryResultRow) {
+        Optional<Double> min = getMinColumnValue(queryResultRow);
+        Optional<Double> avg = getAvgColumnValue(queryResultRow);
+        Optional<Double> max = getMaxColumnValue(queryResultRow);
+        Optional<Integer> numberOfDataPoints = getCountColumnValue(queryResultRow);
+        if (min.isPresent() && avg.isPresent() && max.isPresent() && numberOfDataPoints.isPresent()) {
+            return Optional.of(new MemoryMetric()
+                    .minimum(min.get())
+                    .average(avg.get())
+                    .maximum(max.get())
+                    .numberOfDataPointsForAverage(numberOfDataPoints.get()));
+        }
+        return Optional.empty();
+    }
+}

--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/ValidationStatusAthenaAggregator.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/ValidationStatusAthenaAggregator.java
@@ -1,0 +1,20 @@
+package io.dockstore.metricsaggregator.helper;
+
+import io.dockstore.metricsaggregator.MetricsAggregatorAthenaClient.QueryResultRow;
+import io.dockstore.openapi.client.model.ValidationStatusMetric;
+import java.util.Optional;
+
+/**
+ * TODO: Implement the Validation Status Athena aggregator.
+ */
+public class ValidationStatusAthenaAggregator extends AthenaAggregator<ValidationStatusMetric> {
+    @Override
+    public String getMetricColumnName() {
+        return "*"; // Uses all columns for validationexecutions
+    }
+
+    @Override
+    public Optional<ValidationStatusMetric> createMetricFromQueryResultRow(QueryResultRow queryResultRow) {
+        return Optional.empty();
+    }
+}

--- a/metricsaggregator/src/test/java/io/dockstore/metricsaggregator/common/TestUtilities.java
+++ b/metricsaggregator/src/test/java/io/dockstore/metricsaggregator/common/TestUtilities.java
@@ -35,8 +35,8 @@ import org.apache.commons.configuration2.INIConfiguration;
 public final class TestUtilities {
     public static final String CONFIG_FILE_PATH = ResourceHelpers.resourceFilePath("metrics-aggregator.config");
     public static final MetricsAggregatorConfig METRICS_AGGREGATOR_CONFIG = getMetricsConfig();
-    public static final String BUCKET_NAME = METRICS_AGGREGATOR_CONFIG.getS3Bucket();
-    public static final String ENDPOINT_OVERRIDE = METRICS_AGGREGATOR_CONFIG.getS3EndpointOverride();
+    public static final String BUCKET_NAME = METRICS_AGGREGATOR_CONFIG.getS3Config().bucket();
+    public static final String ENDPOINT_OVERRIDE = METRICS_AGGREGATOR_CONFIG.getS3Config().endpointOverride();
 
     private TestUtilities() {
     }

--- a/metricsaggregator/src/test/resources/metrics-aggregator.config
+++ b/metricsaggregator/src/test/resources/metrics-aggregator.config
@@ -9,5 +9,4 @@ bucketName: local-dockstore-metrics-data
 endpointOverride: http://localhost:4566
 
 [athena]
-database: mydatabase
 outputS3Bucket: s3://aws-athena-query-results-test

--- a/metricsaggregator/src/test/resources/metrics-aggregator.config
+++ b/metricsaggregator/src/test/resources/metrics-aggregator.config
@@ -7,3 +7,7 @@ token: 08932ab0c9ae39a880905666902f8659633ae0232e94ba9f3d2094cb928397e7
 [s3]
 bucketName: local-dockstore-metrics-data
 endpointOverride: http://localhost:4566
+
+[athena]
+database: mydatabase
+outputS3Bucket: s3://aws-athena-query-results-test


### PR DESCRIPTION
**Description**
This PR adds an `--athena` flag to the `aggregate-metrics` command that allows the aggregator to use AWS Athena to aggregate metrics. This is a prototype, so there is still work to be done.

I added a `--skipDockstore` flag that skips sending the metrics to Dockstore and a `--trsId` argument that only aggregates metrics for that entry. This is meant for testing how long the aggregation takes and is likely to be removed once everything is polished.

Currently, the prototype can calculate the following metrics using the workflow executions provided in `ExecutionsRequestBody.runExecutions[]`:
- Execution status metric
- CPU metric
- Memory metric
- Cost metric

Things to be implemented (and some thoughts):
- Calculate execution time metric
  - We currently record execution time as an ISO-8601 duration which doesn't translate well to SQL/AWS Athena. Instead of trying to work around this, I propose that we instead record `startTime` (which is already covered by `dateExecuted`) and `endTime` (not yet recorded) and calculate the duration using SQL. The Terra BQ tables have `workflow_start` and `workflow_end` columns.
- Calculate validation status metric
- Include task executions with workflow execution metric calculation
  - Currently, the metrics aggregator takes task executions that were run during a single workflow execution and converts them to a single workflow execution. It then includes these "converted" workflow executions with actual workflow executions when calculating a metric. We would need to do the "conversion" via SQL then union the result to the other workflow executions 
- Removing executions with duplicate execution IDs
  - The java aggregator removes duplicates by getting the execution that's in the newest file. This can be done via Athena using the "$file_modified_time" field to get the newest execution except you can't use these metadata fields with views and without views, the query is alot harder to read...
- Validating the submitted executions so we can calculate the number of skipped executions
  - The java aggregator retrieved each execution and validated the metric field, but with Athena, we don't see each execution. We could do some light validation using the query, but with the recent webservice changes, bad data shouldn't be able to get in and as far as I'm aware, there's no bad data in prod.
- Testing? Localstack sadly doesn't support Athena in the free version
- Infrastructure changes, such as creating an S3 bucket for the query results and modifying deployer permissions for interacting with AWS Athena

**Some testing results:**
I tested aggregating metrics using the `--trsId` flag which aggregates metrics for all versions of an entry.

To make it a fair comparison, I used `--skipDockstore` so that the aggregator doesn't post the metrics to Dockstore, and I commented out the validation status aggregation for the original Java aggregator.

<details open>
<summary>Staging testing results</summary>

The aggregator was run against the staging metrics bucket which is more representative of production and it has 2023 Terra metrics. I used the `--trsIDs` argument to provide the TRS ID of workflows with many metrics. This causes the aggregator to aggregate metrics for **all versions** of the workflow.

See this [spreadsheet](https://docs.google.com/spreadsheets/d/1MjvCb8IiFtWQGe_3k-Qv7hRP66amFoo4-b3l4yyq1zQ/edit?usp=sharing) for a table comparing the performance of the Java and Athena aggregators.

When I ran the Athena aggregator against all the metrics in staging, it became clear that the creation of views was slowing down the aggregation. A request to create a view took upwards of 500ms and a request to drop a view took upwards of 400ms. This was done for each **version** and it added up
- One of the reasons why the Athena aggregator was slow was because it created a runexecutions view even if there were no run executions. An attempt to fix that was to check the count of the run executions before creating the view via a query, and while that did help, the query that checked the count added to the execution time.
- I ultimately removed the creation of views. While the query may end up looking a bit more complex, it does reduce the execution time. You can see some time comparisons of the aggregator with views and without views

Below is a graph representing some of the data in the spreadsheet. It highlights that as the number of executions increase, Athena is faster at aggregating the metrics. The assumption here is that staging doesn't have many small files of executions unlike QA which has performance test data.
![Java vs Athena Aggregation Time](https://github.com/dockstore/dockstore-support/assets/25287123/a7e7b91a-df19-4ce3-a54e-1a54c89fdf72)
 
</details>

<details>
<summary>QA testing results</summary>

The aggregator was run against the qa-dockstore-metrics-data bucket, which also contains performance testing executions where each file only contains 1 execution. Below is a table showing the aggregator run times against a workflow that has no perf data and a workflow that does.

| **TRS ID**                                                                 | **Number of executions** | **Has perf data** | **Java Aggregator** | **Athena Aggregator** |
|----------------------------------------------------------------------------|--------------------------|-------------------|---------------------|-----------------------|
| [#workflow/github.com/theiagen/public_health_viral_genomics/Mercury_PE_Prep](https://dockstore.org/workflows/github.com/theiagen/public_health_viral_genomics/Mercury_PE_Prep:v2.2.0?tab=metrics) | 203,585                  | no                | 28.7 seconds        | 8.6 seconds           |
| [#workflow/github.com/broadinstitute/viral-pipelines/assemble_refbased](https://dockstore.org/workflows/github.com/broadinstitute/viral-pipelines/assemble_refbased:master?tab=info)      | 13,988                   | yes               | 13.9 seconds               | 35.9 seconds                 |

The Athena aggregator excels when there are many executions in one file, but performs slower when there are many small files in S3, as shown by the slower time for the second workflow which has performance testing data (each file has one execution).

This is explained by point 4 in this [AWS doc for optimizing AWS Athena](https://aws.amazon.com/blogs/big-data/top-10-performance-tuning-tips-for-amazon-athena/):
> Queries run more efficiently when data can be read in parallel, and as much data as possible can be read in a single read request. There is an overhead in reading each file, for example getting metadata, making the request to Amazon S3, and setting up compression dictionaries. This is usually not noticeable, but as the number of files grows, it can add up. To maximize the performance of queries, you should aim for a balance between the number of files and their size.

If Terra submits many executions in one request body, Athena should be faster than the Java aggregation.

</details>

**Q&A**
> What are the observed/perceived pros/cons of using Athena versus the current aggregator?

In my experience with writing both the Athena and Java aggregation, Athena is more intuitive and maintainable. For starters, we don't have to interact with S3 to get all the executions to aggregate. Athena does it for us in the background when we execute the query. To aggregate metrics, queries are easier to write and understand than writing Java code to perform aggregations. For example, to calculate metrics for each status, I just need to add a `GROUP BY execution status` clause to the Athena query where as for the Java aggregation, I have to create those groups myself in Java then calculate the metrics. A second example is that aggregating metrics over ALL platforms is much easier via a SQL query. For Java, we aggregated a list of aggregated metrics.

I wouldn't really call this a con, but we have to be mindful of optimizing our S3 files if we use Athena. We also have some things in place that don't translate well to Athena/SQL, so we might have to rework it.

> having done both Java and AWS Athena, which would you consider easier/simpler/maintainable/etc. if we needed to ingest and then aggregate more metrics in the future if there is not a clear performance improvement?

AWS Athena felt much simpler for me because it's more intuitive to write aggregation SQL queries vs aggregation code. 

I would hesitate to say that there is not a clear performance improvement because our current S3 files are not fully optimized for Athena (i.e. it's currently possible to have many small files). I would say that the first testing result in the table above is the most accurate performance representation of both the Athena and Java aggregators because it represents the data in production. The second testing result is a warning that Athena is not that useful if we don't optimize our files, but this is something that is fixable.

**Review Instructions**
n/a

**Issue**
[SEAB-6347](https://ucsc-cgl.atlassian.net/browse/SEAB-6347)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[SEAB-6347]: https://ucsc-cgl.atlassian.net/browse/SEAB-6347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ