### PR TITLE
Do some JIRA/GitHub version syncing

### DIFF
--- a/jira_automation/README.md
+++ b/jira_automation/README.md
@@ -13,8 +13,8 @@ a configuration issue again, it could be useful in the future.
 
 # Auth
 
-* ResolutionChecker and MilestoneCheck require environment variable `GITHUB_TOKEN` be set to a GitHub personal access token.
-* SprintStart requires the environment variable `JIRA_TOKEN` be set to a JIRA token.
+* ResolutionChecker, MilestoneChecker, and MilestoneResolver require the environment variable `GITHUB_TOKEN` be set to a GitHub personal access token that has access to dockstore GitHub issues
+* SprintStart and MilestoneResolver require the environment variable `JIRA_TOKEN` be set to a JIRA token.
 
 # Usage
 
@@ -24,6 +24,6 @@ I usually run in IntelliJ with a Run Configuration
 2. Add the environment variable `GITHUB_TOKEN` to your GitHub token.
 3. For MilestoneResolver, you also need to set these environment variables:
     * `JIRA_USERNAME` to your JIRA user, e.g., jdoe@ucsc.edu
-    * `JIRA_TOKEN` to a your JIRA token
-3. The console will print out generated queries, which you then paste into your browser.
+    * `JIRA_TOKEN` to your JIRA token
+3. The console will print out generated urls, which you then paste into your browser.
 

--- a/jira_automation/README.md
+++ b/jira_automation/README.md
@@ -24,6 +24,6 @@ I usually run in IntelliJ with a Run Configuration
 2. Add the environment variable `GITHUB_TOKEN` to your GitHub token.
 3. For MilestoneResolver, you also need to set these environment variables:
     * `JIRA_USERNAME` to your JIRA user, e.g., jdoe@ucsc.edu
-    * `JIRA_TOKEN` to your JIRA token
-3. The console will print out generated urls, which you then paste into your browser.
+    * `JIRA_TOKEN` to a your JIRA token
+3. The console will print out generated queries, which you then paste into your browser.
 

--- a/jira_automation/README.md
+++ b/jira_automation/README.md
@@ -3,9 +3,10 @@ There are three applications in here to facilitate our JIRA/GitHub interaction
 1. io.dockstore.jira.MilestoneChecker - generates GitHub and JQL queries to find mismatches in the JIRA fix version and GitHub milestone. The JIRA fix version is
    a multi-value field; the GitHub milestone is a single-value field, so Unito doesn't sync them. We have to remember to manually
    keep them in sync; this program identifies cases we've missed.
-2. SprintStart - a barely started work in progress to automatically generate review tickets at the beginning of a sprint, which
+2. io.dockstore.jira.MilestoneResolver - Updates JIRA and GitHub
+3. SprintStart - a barely started work in progress to automatically generate review tickets at the beginning of a sprint, which
    is currently a manual and tedious process.
-3. io.dockstore.jira.ResolutionChecker - used to help find issues open in GitHub that are closed in JIRA. This was to diagnose an issue where 
+4. io.dockstore.jira.ResolutionChecker - used to help find issues open in GitHub that are closed in JIRA. This was to diagnose an issue where 
 Unito was seemingly mysteriously closing JIRA issues at random. It turned out to be because we hadn't properly configured
 a GitHub and JIRA user in Unito -- it's the Unito intended behavior. We currently don't need to run this, although if we have
 a configuration issue again, it could be useful in the future.
@@ -21,5 +22,8 @@ I usually run in IntelliJ with a Run Configuration
 
 1. In Run Configuration, set the main class to io.dockstore.jira.MilestoneChecker or io.dockstore.jira.ResolutionChecker
 2. Add the environment variable `GITHUB_TOKEN` to your GitHub token.
+3. For MilestoneResolver, you also need to set these environment variables:
+    * `JIRA_USERNAME` to your JIRA user, e.g., jdoe@ucsc.edu
+    * `JIRA_TOKEN` to a your JIRA token
 3. The console will print out generated queries, which you then paste into your browser.
 

--- a/jira_automation/README.md
+++ b/jira_automation/README.md
@@ -24,6 +24,6 @@ I usually run in IntelliJ with a Run Configuration
 2. Add the environment variable `GITHUB_TOKEN` to your GitHub token.
 3. For MilestoneResolver, you also need to set these environment variables:
     * `JIRA_USERNAME` to your JIRA user, e.g., jdoe@ucsc.edu
-    * `JIRA_TOKEN` to a your JIRA token
-3. The console will print out generated queries, which you then paste into your browser.
+    * `JIRA_TOKEN` to your JIRA token
+3. The console will print out generated urls, which you then paste into your browser.
 

--- a/jira_automation/pom.xml
+++ b/jira_automation/pom.xml
@@ -62,7 +62,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
-            <id>topicGeneratorClient</id>
+            <id>milestoneResolverId</id>
             <phase>package</phase>
             <goals>
               <goal>shade</goal>
@@ -86,9 +86,6 @@
                 <exclude>META-INF/*.SF</exclude>
                 <exclude>META-INF/*.DSA</exclude>
                 <exclude>META-INF/*.RSA</exclude>
-                <!-- not sure why this results in error unline our other repos  if not excluded -->
-                <exclude>migrations.xml</exclude>
-                <exclude>migrations.*.xml</exclude>
               </excludes>
             </filter>
           </filters>

--- a/jira_automation/pom.xml
+++ b/jira_automation/pom.xml
@@ -42,6 +42,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/jira_automation/pom.xml
+++ b/jira_automation/pom.xml
@@ -42,10 +42,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
 
   </dependencies>
 

--- a/jira_automation/pom.xml
+++ b/jira_automation/pom.xml
@@ -38,6 +38,14 @@
       <artifactId>gson</artifactId>
       <version>2.10.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
 
   </dependencies>
 
@@ -53,6 +61,44 @@
           <forceJavacCompilerUse>true</forceJavacCompilerUse>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>topicGeneratorClient</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Main-Class>io.dockstore.jira.MilestoneResolver</Main-Class>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+        <configuration>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+                <!-- not sure why this results in error unline our other repos  if not excluded -->
+                <exclude>migrations.xml</exclude>
+                <exclude>migrations.*.xml</exclude>
+              </excludes>
+            </filter>
+          </filters>
+        </configuration>
+      </plugin>
+
     </plugins>
 
   </build>

--- a/jira_automation/src/main/java/io/dockstore/jira/JiraIssue.java
+++ b/jira_automation/src/main/java/io/dockstore/jira/JiraIssue.java
@@ -1,0 +1,9 @@
+package io.dockstore.jira;
+
+import java.util.Date;
+
+public record JiraIssue(String key, Fields fields) { }
+
+record Fields(Date updated, FixVersion[] fixVersions) { }
+
+record FixVersion(String name) { }

--- a/jira_automation/src/main/java/io/dockstore/jira/JiraIssue.java
+++ b/jira_automation/src/main/java/io/dockstore/jira/JiraIssue.java
@@ -2,8 +2,18 @@ package io.dockstore.jira;
 
 import java.util.Date;
 
+/**
+ * JIRA Rest API models. There is no OpenAPI definition nor Java library I could find that worked;
+ * this models the parts of the entities that we consume, e.g., <code>JiraIssue</code> has many
+ * more properties than the record has here, but we only need to access the ones in the record.
+ * @param key
+ * @param fields
+ */
 public record JiraIssue(String key, Fields fields) { }
 
 record Fields(Date updated, FixVersion[] fixVersions) { }
 
 record FixVersion(String name) { }
+
+record UpdateJiraIssue(UpdateFields fields) { }
+record UpdateFields(FixVersion[] fixVersions) { }

--- a/jira_automation/src/main/java/io/dockstore/jira/MilestoneChecker.java
+++ b/jira_automation/src/main/java/io/dockstore/jira/MilestoneChecker.java
@@ -1,6 +1,7 @@
 package io.dockstore.jira;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -14,6 +15,19 @@ import org.kohsuke.github.GHMilestone;
  * in JIRA. Works by looking at all open GitHub issues, then reading the info Unito appends to the
  * description in GitHub, which includes the fix version. It compares the fix version in JIRA with
  * the milestone of the GitHub issue.
+ *
+ * <p>The description of a GitHub issue is updated by Unito to look like this:</p>
+ *
+ * <pre>
+ * ┆Issue is synchronized with this Jira Story
+ * ┆Fix Versions: Dockstore 1.16
+ * ┆Issue Number: DOCK-2519
+ * ┆Sprint: 136 - Izmir
+ * ┆Issue Type: Story
+ * </pre>
+ * 
+ * <p>We can tell if JIRA fix version and GitHub milestone are out of sync by comparing the Fix Version string above with the
+ * GitHub issue milestone.</p>
  */
 public final class MilestoneChecker {
 
@@ -22,33 +36,93 @@ public final class MilestoneChecker {
      *  the "1.15"
       */
     private static final Pattern FIX_VERSIONS = Pattern.compile("((Fix Versions)|(fixVersions))(:\\s*(Dockstore )?(.*))");
+    private static final Pattern JIRA_ISSUE = Pattern.compile("((Issue Number)|(friendlyId)): (DOCK-\\d+)");
 
     private MilestoneChecker() { }
 
     public static void main(String[] args) throws IOException {
-        final List<GHIssue> openIssues = Utils.findOpenIssues(Utils.getDockstoreRepository());
-        final List<JiraAndGithub> issues = openIssues.stream()
-            .filter(ghIssue -> {
-                final GHMilestone milestone = ghIssue.getMilestone();
-                final String body = ghIssue.getBody();
-                final Matcher matcher = FIX_VERSIONS.matcher(body);
-                if (matcher.find()) {
-                    if (milestone == null) {
-                        // There's a fix version in JIRA, but none in GitHub
-                        return true;
+        final List<JiraAndGithub> mismatchedIssues = findMismatchedIssues();
+        if (mismatchedIssues.isEmpty()) {
+            System.out.println("The JIRA fix version and GitHub milestone are in sync for all DOCK issues");
+        } else {
+            System.out.println("The following issues are mismatched:");
+            mismatchedIssues.forEach(MilestoneChecker::printMismatchedIssue);
+        }
+        mismatchedIssues.forEach(issue -> {
+            final GHIssue gitHubIssue = issue.ghIssue;
+            final String body = gitHubIssue.getBody();
+            final Matcher issueMatcher = JIRA_ISSUE.matcher(body);
+            final boolean found = issueMatcher.find();
+            if (!found) {
+                System.out.println("Milestone in GitHub but not in JIRA, " + issue);
+            } else {
+                try {
+                    final JiraIssue jiraIssue = Utils.getJiraIssue(issue.jiraIssue);
+                    final FixVersion[] fixVersions = jiraIssue.fields().fixVersions();
+                    if (fixVersions.length == 0) {
+                        System.out.println("No fix version in JIRA, need to set it to " + gitHubIssue.getMilestone());
                     }
-                    final String jiraFixVersion = matcher.group(6);
-                    return !milestoneAndFixVersionEqual(jiraFixVersion, milestone.getTitle());
-                } else {
-                    // No fix version in JIRA, is there one in Dockstore?
-                    return milestone != null;
+                    else if (fixVersions.length > 1) {
+                        System.out.println("Too many fix versions in Jira = " + jiraIssue);
+                    } else {
+                        if (jiraIssue.fields().updated().after(gitHubIssue.getUpdatedAt())) {
+                            System.out.println("Gotta update GitHub milestone = " + issue);
+                        } else {
+                            System.out.println("Gotta update jira issue fix version = " + issue);
+                        }
+                    }
+                } catch (URISyntaxException e) {
+                    throw new RuntimeException(e);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
                 }
+            }
+        });
+    }
+
+    private static void printMismatchedIssue(final JiraAndGithub issue) {
+        final GHIssue ghIssue = issue.ghIssue;
+        System.out.println(
+            "GitHub %s, milestone %s; JIRA issue %s, fix version %s".formatted(
+                ghIssue.getNumber(),
+                ghIssue.getMilestone().getTitle(),
+                issue.jiraIssue,
+                findJiraFixVersion(ghIssue.getBody())));
+    }
+
+    /**
+     * Finds issues where the GitHub milestone does not match the JIRA fix version
+     * @return
+     * @throws IOException
+     */
+    private static List<JiraAndGithub> findMismatchedIssues() throws IOException {
+        final List<GHIssue> openIssues = Utils.findOpenIssues(Utils.getDockstoreRepository());
+        return openIssues.stream()
+            .filter(MilestoneChecker::milestoneAndFixVersionMismatch)
+            .map(ghIssue -> {
+                // If empty, Unito hasn't synced yet
+                return Utils.findJiraIssueInBody(ghIssue)
+                    .map(jiraIssue -> new JiraAndGithub(jiraIssue, ghIssue)).orElse(null);
             })
-            .map(ghIssue -> new JiraAndGithub(Utils.findJiraIssueInBody(ghIssue).get(), ghIssue.getNumber()))
+            .filter(Objects::nonNull)
             .collect(Collectors.toList());
-        System.out.println(generateGitHubIssuesUrl(issues));
-        System.out.println();
-        System.out.println(generateJiraIssuesUrl(issues));
+    }
+
+    private static boolean milestoneAndFixVersionMismatch(final GHIssue ghIssue) {
+        final GHMilestone milestone = ghIssue.getMilestone();
+        final String body = ghIssue.getBody();
+        final String jiraFixVersion = findJiraFixVersion(body);
+        if (jiraFixVersion != null) {
+            if (milestone == null) {
+                // There's a fix version in JIRA, but none in GitHub
+                return true;
+            }
+            return !milestoneAndFixVersionEqual(jiraFixVersion, milestone.getTitle());
+        } else { // No fix version in JIRA, is there one in GitHub?
+            return milestone != null;
+        }
     }
 
     private static String generateJiraIssuesUrl(final List<JiraAndGithub> issues) {
@@ -59,7 +133,7 @@ public final class MilestoneChecker {
 
     private static String generateGitHubIssuesUrl(final List<JiraAndGithub> issues) {
         return "https://github.com/dockstore/dockstore/issues?q="
-            + issues.stream().map(issue -> "" + issue.githubIssue())
+            + issues.stream().map(issue -> "" + issue.ghIssue.getNumber())
             .collect(Collectors.joining("+"));
     }
 
@@ -68,5 +142,13 @@ public final class MilestoneChecker {
             || Objects.equals(jiraFixVersion, milestone);
     }
 
-    record JiraAndGithub(String jiraIssue, int githubIssue) { }
+    private static String findJiraFixVersion(String gitHubIssueBody) {
+        final Matcher matcher = FIX_VERSIONS.matcher(gitHubIssueBody);
+        if (matcher.find()) {
+            return matcher.group(6);
+        }
+        return null;
+    }
+
+    record JiraAndGithub(String jiraIssue, GHIssue ghIssue) { }
 }

--- a/jira_automation/src/main/java/io/dockstore/jira/MilestoneChecker.java
+++ b/jira_automation/src/main/java/io/dockstore/jira/MilestoneChecker.java
@@ -1,7 +1,6 @@
 package io.dockstore.jira;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -15,19 +14,6 @@ import org.kohsuke.github.GHMilestone;
  * in JIRA. Works by looking at all open GitHub issues, then reading the info Unito appends to the
  * description in GitHub, which includes the fix version. It compares the fix version in JIRA with
  * the milestone of the GitHub issue.
- *
- * <p>The description of a GitHub issue is updated by Unito to look like this:</p>
- *
- * <pre>
- * ┆Issue is synchronized with this Jira Story
- * ┆Fix Versions: Dockstore 1.16
- * ┆Issue Number: DOCK-2519
- * ┆Sprint: 136 - Izmir
- * ┆Issue Type: Story
- * </pre>
- * 
- * <p>We can tell if JIRA fix version and GitHub milestone are out of sync by comparing the Fix Version string above with the
- * GitHub issue milestone.</p>
  */
 public final class MilestoneChecker {
 
@@ -36,93 +22,33 @@ public final class MilestoneChecker {
      *  the "1.15"
       */
     private static final Pattern FIX_VERSIONS = Pattern.compile("((Fix Versions)|(fixVersions))(:\\s*(Dockstore )?(.*))");
-    private static final Pattern JIRA_ISSUE = Pattern.compile("((Issue Number)|(friendlyId)): (DOCK-\\d+)");
 
     private MilestoneChecker() { }
 
     public static void main(String[] args) throws IOException {
-        final List<JiraAndGithub> mismatchedIssues = findMismatchedIssues();
-        if (mismatchedIssues.isEmpty()) {
-            System.out.println("The JIRA fix version and GitHub milestone are in sync for all DOCK issues");
-        } else {
-            System.out.println("The following issues are mismatched:");
-            mismatchedIssues.forEach(MilestoneChecker::printMismatchedIssue);
-        }
-        mismatchedIssues.forEach(issue -> {
-            final GHIssue gitHubIssue = issue.ghIssue;
-            final String body = gitHubIssue.getBody();
-            final Matcher issueMatcher = JIRA_ISSUE.matcher(body);
-            final boolean found = issueMatcher.find();
-            if (!found) {
-                System.out.println("Milestone in GitHub but not in JIRA, " + issue);
-            } else {
-                try {
-                    final JiraIssue jiraIssue = Utils.getJiraIssue(issue.jiraIssue);
-                    final FixVersion[] fixVersions = jiraIssue.fields().fixVersions();
-                    if (fixVersions.length == 0) {
-                        System.out.println("No fix version in JIRA, need to set it to " + gitHubIssue.getMilestone());
-                    }
-                    else if (fixVersions.length > 1) {
-                        System.out.println("Too many fix versions in Jira = " + jiraIssue);
-                    } else {
-                        if (jiraIssue.fields().updated().after(gitHubIssue.getUpdatedAt())) {
-                            System.out.println("Gotta update GitHub milestone = " + issue);
-                        } else {
-                            System.out.println("Gotta update jira issue fix version = " + issue);
-                        }
-                    }
-                } catch (URISyntaxException e) {
-                    throw new RuntimeException(e);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        });
-    }
-
-    private static void printMismatchedIssue(final JiraAndGithub issue) {
-        final GHIssue ghIssue = issue.ghIssue;
-        System.out.println(
-            "GitHub %s, milestone %s; JIRA issue %s, fix version %s".formatted(
-                ghIssue.getNumber(),
-                ghIssue.getMilestone().getTitle(),
-                issue.jiraIssue,
-                findJiraFixVersion(ghIssue.getBody())));
-    }
-
-    /**
-     * Finds issues where the GitHub milestone does not match the JIRA fix version
-     * @return
-     * @throws IOException
-     */
-    private static List<JiraAndGithub> findMismatchedIssues() throws IOException {
         final List<GHIssue> openIssues = Utils.findOpenIssues(Utils.getDockstoreRepository());
-        return openIssues.stream()
-            .filter(MilestoneChecker::milestoneAndFixVersionMismatch)
-            .map(ghIssue -> {
-                // If empty, Unito hasn't synced yet
-                return Utils.findJiraIssueInBody(ghIssue)
-                    .map(jiraIssue -> new JiraAndGithub(jiraIssue, ghIssue)).orElse(null);
+        final List<JiraAndGithub> issues = openIssues.stream()
+            .filter(ghIssue -> {
+                final GHMilestone milestone = ghIssue.getMilestone();
+                final String body = ghIssue.getBody();
+                final Matcher matcher = FIX_VERSIONS.matcher(body);
+                if (matcher.find()) {
+                    if (milestone == null) {
+                        // There's a fix version in JIRA, but none in GitHub
+                        return true;
+                    }
+                    final String jiraFixVersion = matcher.group(6);
+                    return !milestoneAndFixVersionEqual(jiraFixVersion, milestone.getTitle());
+                } else {
+                    // No fix version in JIRA, is there one in Dockstore?
+                    return milestone != null;
+                }
             })
-            .filter(Objects::nonNull)
+            .map(ghIssue -> new JiraAndGithub(Utils.findJiraIssueInBody(ghIssue).get(), ghIssue.getNumber()))
             .collect(Collectors.toList());
-    }
-
-    private static boolean milestoneAndFixVersionMismatch(final GHIssue ghIssue) {
-        final GHMilestone milestone = ghIssue.getMilestone();
-        final String body = ghIssue.getBody();
-        final String jiraFixVersion = findJiraFixVersion(body);
-        if (jiraFixVersion != null) {
-            if (milestone == null) {
-                // There's a fix version in JIRA, but none in GitHub
-                return true;
-            }
-            return !milestoneAndFixVersionEqual(jiraFixVersion, milestone.getTitle());
-        } else { // No fix version in JIRA, is there one in GitHub?
-            return milestone != null;
-        }
+        System.out.println(generateGitHubIssuesUrl(issues));
+        System.out.println();
+        System.out.println(generateJiraIssuesUrl(issues));
     }
 
     private static String generateJiraIssuesUrl(final List<JiraAndGithub> issues) {
@@ -133,7 +59,7 @@ public final class MilestoneChecker {
 
     private static String generateGitHubIssuesUrl(final List<JiraAndGithub> issues) {
         return "https://github.com/dockstore/dockstore/issues?q="
-            + issues.stream().map(issue -> "" + issue.ghIssue.getNumber())
+            + issues.stream().map(issue -> "" + issue.githubIssue())
             .collect(Collectors.joining("+"));
     }
 
@@ -142,13 +68,5 @@ public final class MilestoneChecker {
             || Objects.equals(jiraFixVersion, milestone);
     }
 
-    private static String findJiraFixVersion(String gitHubIssueBody) {
-        final Matcher matcher = FIX_VERSIONS.matcher(gitHubIssueBody);
-        if (matcher.find()) {
-            return matcher.group(6);
-        }
-        return null;
-    }
-
-    record JiraAndGithub(String jiraIssue, GHIssue ghIssue) { }
+    record JiraAndGithub(String jiraIssue, int githubIssue) { }
 }

--- a/jira_automation/src/main/java/io/dockstore/jira/MilestoneChecker.java
+++ b/jira_automation/src/main/java/io/dockstore/jira/MilestoneChecker.java
@@ -1,7 +1,6 @@
 package io.dockstore.jira;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -15,19 +14,6 @@ import org.kohsuke.github.GHMilestone;
  * in JIRA. Works by looking at all open GitHub issues, then reading the info Unito appends to the
  * description in GitHub, which includes the fix version. It compares the fix version in JIRA with
  * the milestone of the GitHub issue.
- *
- * <p>The description of a GitHub issue is updated by Unito to look like this:</p>
- *
- * <pre>
- * ┆Issue is synchronized with this Jira Story
- * ┆Fix Versions: Dockstore 1.16
- * ┆Issue Number: DOCK-2519
- * ┆Sprint: 136 - Izmir
- * ┆Issue Type: Story
- * </pre>
- * 
- * <p>We can tell if JIRA fix version and GitHub milestone are out of sync by comparing the Fix Version string above with the
- * GitHub issue milestone.</p>
  */
 public final class MilestoneChecker {
 
@@ -36,93 +22,33 @@ public final class MilestoneChecker {
      *  the "1.15"
       */
     private static final Pattern FIX_VERSIONS = Pattern.compile("((Fix Versions)|(fixVersions))(:\\s*(Dockstore )?(.*))");
-    private static final Pattern JIRA_ISSUE = Pattern.compile("((Issue Number)|(friendlyId)): (DOCK-\\d+)");
 
     private MilestoneChecker() { }
 
     public static void main(String[] args) throws IOException {
-        final List<JiraAndGithub> mismatchedIssues = findMismatchedIssues();
-        if (mismatchedIssues.isEmpty()) {
-            System.out.println("The JIRA fix version and GitHub milestone are in sync for all DOCK issues");
-        } else {
-            System.out.println("The following issues are mismatched:");
-            mismatchedIssues.forEach(MilestoneChecker::printMismatchedIssue);
-        }
-        mismatchedIssues.forEach(issue -> {
-            final GHIssue gitHubIssue = issue.ghIssue;
-            final String body = gitHubIssue.getBody();
-            final Matcher issueMatcher = JIRA_ISSUE.matcher(body);
-            final boolean found = issueMatcher.find();
-            if (!found) {
-                System.out.println("Milestone in GitHub but not in JIRA, " + issue);
-            } else {
-                try {
-                    final JiraIssue jiraIssue = Utils.getJiraIssue(issue.jiraIssue);
-                    final FixVersion[] fixVersions = jiraIssue.fields().fixVersions();
-                    if (fixVersions.length == 0) {
-                        System.out.println("No fix version in JIRA, need to set it to " + gitHubIssue.getMilestone());
-                    }
-                    else if (fixVersions.length > 1) {
-                        System.out.println("Too many fix versions in Jira = " + jiraIssue);
-                    } else {
-                        if (jiraIssue.fields().updated().after(gitHubIssue.getUpdatedAt())) {
-                            System.out.println("Gotta update GitHub milestone = " + issue);
-                        } else {
-                            System.out.println("Gotta update jira issue fix version = " + issue);
-                        }
-                    }
-                } catch (URISyntaxException e) {
-                    throw new RuntimeException(e);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        });
-    }
-
-    private static void printMismatchedIssue(final JiraAndGithub issue) {
-        final GHIssue ghIssue = issue.ghIssue;
-        System.out.println(
-            "GitHub %s, milestone %s; JIRA issue %s, fix version %s".formatted(
-                ghIssue.getNumber(),
-                ghIssue.getMilestone().getTitle(),
-                issue.jiraIssue,
-                findJiraFixVersion(ghIssue.getBody())));
-    }
-
-    /**
-     * Finds issues where the GitHub milestone does not match the JIRA fix version
-     * @return
-     * @throws IOException
-     */
-    private static List<JiraAndGithub> findMismatchedIssues() throws IOException {
         final List<GHIssue> openIssues = Utils.findOpenIssues(Utils.getDockstoreRepository());
-        return openIssues.stream()
-            .filter(MilestoneChecker::milestoneAndFixVersionMismatch)
-            .map(ghIssue -> {
-                // If empty, Unito hasn't synced yet
-                return Utils.findJiraIssueInBody(ghIssue)
-                    .map(jiraIssue -> new JiraAndGithub(jiraIssue, ghIssue)).orElse(null);
+        final List<JiraAndGithub> issues = openIssues.stream()
+            .filter(ghIssue -> {
+                final GHMilestone milestone = ghIssue.getMilestone();
+                final String body = ghIssue.getBody();
+                final Matcher matcher = FIX_VERSIONS.matcher(body);
+                if (matcher.find()) {
+                    if (milestone == null) {
+                        // There's a fix version in JIRA, but none in GitHub
+                        return true;
+                    }
+                    final String jiraFixVersion = matcher.group(6);
+                    return !milestoneAndFixVersionEqual(jiraFixVersion, milestone.getTitle());
+                } else {
+                    // No fix version in JIRA, is there one in Dockstore?
+                    return milestone != null;
+                }
             })
-            .filter(Objects::nonNull)
+            .map(ghIssue -> new JiraAndGithub(Utils.findJiraIssueInBody(ghIssue).get(), ghIssue.getNumber()))
             .collect(Collectors.toList());
-    }
-
-    private static boolean milestoneAndFixVersionMismatch(final GHIssue ghIssue) {
-        final GHMilestone milestone = ghIssue.getMilestone();
-        final String body = ghIssue.getBody();
-        final String jiraFixVersion = findJiraFixVersion(body);
-        if (jiraFixVersion != null) {
-            if (milestone == null) {
-                // There's a fix version in JIRA, but none in GitHub
-                return true;
-            }
-            return !milestoneAndFixVersionEqual(jiraFixVersion, milestone.getTitle());
-        } else { // No fix version in JIRA, is there one in GitHub?
-            return milestone != null;
-        }
+        System.out.println(generateGitHubIssuesUrl(issues));
+        System.out.println();
+        System.out.println(generateJiraIssuesUrl(issues));
     }
 
     private static String generateJiraIssuesUrl(final List<JiraAndGithub> issues) {
@@ -133,22 +59,14 @@ public final class MilestoneChecker {
 
     private static String generateGitHubIssuesUrl(final List<JiraAndGithub> issues) {
         return "https://github.com/dockstore/dockstore/issues?q="
-            + issues.stream().map(issue -> "" + issue.ghIssue.getNumber())
+            + issues.stream().map(issue -> "" + issue.githubIssue())
             .collect(Collectors.joining("+"));
     }
 
     private static boolean milestoneAndFixVersionEqual(String jiraFixVersion, String milestone) {
-        return "Open-ended research tasks".equals(jiraFixVersion) && "Open ended research tasks".equals(milestone)
+        return Utils.JIRA_OPEN_ENDED_RESEARCH_TASKS.equals(jiraFixVersion) && Utils.GITHUB_OPEN_ENDED_RESEARCH_TASKS.equals(milestone)
             || Objects.equals(jiraFixVersion, milestone);
     }
 
-    private static String findJiraFixVersion(String gitHubIssueBody) {
-        final Matcher matcher = FIX_VERSIONS.matcher(gitHubIssueBody);
-        if (matcher.find()) {
-            return matcher.group(6);
-        }
-        return null;
-    }
-
-    record JiraAndGithub(String jiraIssue, GHIssue ghIssue) { }
+    record JiraAndGithub(String jiraIssue, int githubIssue) { }
 }

--- a/jira_automation/src/main/java/io/dockstore/jira/MilestoneResolver.java
+++ b/jira_automation/src/main/java/io/dockstore/jira/MilestoneResolver.java
@@ -73,7 +73,7 @@ public final class MilestoneResolver {
                     // There's a JIRA fix version, but no GitHub milestone, set the GitHub milestone
                     updateGitHubMilestone(gitHubIssue.getNumber(), fixVersions[0].name());
                 } else {
-                    LOG.info("The fix version and milestone mismatch must be resolved manually for: {}}", getJiraIssueUrl(issue.jiraIssueId));
+                    LOG.info("The fix version and milestone mismatch must be resolved manually for: {}", getJiraIssueUrl(issue.jiraIssueId));
                 }
             } catch (URISyntaxException | IOException | InterruptedException e) {
                 LOG.error("Error resolving %s".formatted(issue), e);
@@ -144,12 +144,6 @@ public final class MilestoneResolver {
         } else { // No fix version in JIRA, is there one in GitHub?
             return milestone != null;
         }
-    }
-
-    private static String generateJiraIssuesUrl(final List<MilestoneResolver.JiraAndGithub> issues) {
-        return "https://ucsc-cgl.atlassian.net/issues/?jql=project=DOCK AND "
-            + issues.stream().map(issue -> "key=\"" + issue.jiraIssueId() + "\"")
-            .collect(Collectors.joining(" or "));
     }
 
     private static String getJiraIssueUrl(String issueNumber) {

--- a/jira_automation/src/main/java/io/dockstore/jira/MilestoneResolver.java
+++ b/jira_automation/src/main/java/io/dockstore/jira/MilestoneResolver.java
@@ -53,9 +53,9 @@ public final class MilestoneResolver {
     public static void main(String[] args) throws IOException {
         final List<JiraAndGithub> mismatchedIssues = findMismatchedIssues();
         if (mismatchedIssues.isEmpty()) {
-            System.out.println("The JIRA fix version and GitHub milestone are in sync for all DOCK issues");
+            LOG.info("The JIRA fix version and GitHub milestone are in sync for all DOCK issues");
         } else {
-            System.out.println("The following issues are mismatched:");
+            LOG.info("The following issues are mismatched:");
             mismatchedIssues.forEach(MilestoneResolver::printMismatchedIssue);
         }
         mismatchedIssues.forEach(issue -> {
@@ -64,7 +64,7 @@ public final class MilestoneResolver {
                 final JiraIssue jiraIssue = Utils.getJiraIssue(issue.jiraIssueId);
                 final GHMilestone ghMilestone = gitHubIssue.getMilestone();
                 final String jiraIssueUrl = getJiraIssueUrl(jiraIssue.key());
-                System.out.println("Processing JIRA issue %s".formatted(jiraIssueUrl));
+                LOG.info("Processing JIRA issue {}", jiraIssueUrl);
                 final FixVersion[] fixVersions = jiraIssue.fields().fixVersions();
                 if (fixVersions.length == 0) {
                     // There is GitHub milestone but no JIRA fix version
@@ -73,20 +73,19 @@ public final class MilestoneResolver {
                     // There's a JIRA fix version, but no GitHub milestone, set the GitHub milestone
                     updateGitHubMilestone(gitHubIssue.getNumber(), fixVersions[0].name());
                 } else {
-                    System.out.println("The fix version and milestone mismatch must be resolved manually for: %s".formatted(getJiraIssueUrl(issue.jiraIssueId)));
+                    LOG.info("The fix version and milestone mismatch must be resolved manually for: {}}", getJiraIssueUrl(issue.jiraIssueId));
                 }
             } catch (URISyntaxException | IOException | InterruptedException e) {
                 LOG.error("Error resolving %s".formatted(issue), e);
-                throw new RuntimeException(e);
             }
         });
     }
 
     private static void updateGitHubMilestone(int gitHubIssue, String jiraFixVersion) {
         if (Utils.updateGitHubMilestone(gitHubIssue, jiraFixVersion)) {
-            System.out.println("Updated GitHub milestone in %s to %s".formatted(gitHubIssue, jiraFixVersion));
+            LOG.info("Updated GitHub milestone in {} to {}", gitHubIssue, jiraFixVersion);
         } else {
-            System.err.println("Failed to update GitHub milestone in %s".formatted(gitHubIssue));
+            LOG.error("Failed to update GitHub milestone in {}", gitHubIssue);
         }
     }
 
@@ -94,10 +93,9 @@ public final class MilestoneResolver {
         throws URISyntaxException, IOException, InterruptedException {
         final String jiraIssueUrl = getJiraIssueUrl(jiraIssue);
         if (Utils.updateJiraFixVersion(jiraIssue, gitHubMilestone)) {
-            System.out.println("Updated fix version in %s to %s".formatted(jiraIssueUrl,
-                gitHubMilestone));
+            LOG.info("Updated fix version in {} to {}", jiraIssueUrl, gitHubMilestone);
         } else {
-            System.err.println("Failed to update fix version in %s".formatted(jiraIssueUrl));
+            LOG.error("Failed to update fix version in {}", jiraIssueUrl);
         }
     }
 
@@ -107,12 +105,12 @@ public final class MilestoneResolver {
         final String notSet = "<not set>";
         final String milestone = ghMilestone != null ? ghMilestone.getTitle() : notSet;
         final String jiraFixVersion = findJiraFixVersion(ghIssue.getBody()).orElse(notSet);
-        System.out.println(
-            "GitHub %s, milestone %s; JIRA %s, fix version %s".formatted(
+        LOG.info(
+            "GitHub {}, milestone {}; JIRA {}, fix version {}",
                 ghIssue.getNumber(),
                 milestone,
                 issue.jiraIssueId,
-                jiraFixVersion));
+                jiraFixVersion);
     }
 
     /**

--- a/jira_automation/src/main/java/io/dockstore/jira/MilestoneResolver.java
+++ b/jira_automation/src/main/java/io/dockstore/jira/MilestoneResolver.java
@@ -1,0 +1,181 @@
+package io.dockstore.jira;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHMilestone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Attempts to resolve JIRA DOCK ticket fix version mismatches with the corresponding GitHub milestone.
+ * Handles these cases:
+ *
+ * <ol>
+ *     <li>There is a JIRA fix version but no GitHub milestone -- sets the GitHub milestone to the JIRA fix version</li>
+ *     <li>There is a GitHub milestone but no JIRA fix version -- sets the JIRA fix version to the GitHub milestone</li>
+ * </ol>
+ *
+ * <p>It does not handle the case of the JIRA fix version not matching the GitHub milestone. It does
+ * print out a message saying the mismatch needs to be resolved manually. To resolve this automatically,
+ * the program would need to:</p>
+ *
+ * <ol>
+ *     <li>Figure out the timestamp of when the JIRA fix version was last set</li>
+ *     <li>Figure out the timestamp of when the GitHub milestone was set</li>
+ *     <li>Resolve the difference by using the most recently changed.</li>
+ * </ol>
+ *
+ * <p>This is possible, but didn't seem worth the extra work at this point. See
+ * https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-changelog-get to get
+ * the JIRA change log. Note that it is paginated so the invoker would have to account for that.</p>
+ *
+ */
+public final class MilestoneResolver {
+
+    /**
+     *  Pattern for finding a substring like "Fix Versions: Dockstore 1.15" in GitHub issue body, to extract
+     *  the "1.15"
+     */
+    private static final Pattern FIX_VERSIONS = Pattern.compile("((Fix Versions)|(fixVersions))(:\\s*(Dockstore )?(.*))");
+    private static final int FIX_VERSION_REG_EX_GROUP = 6;
+
+    private static final Logger LOG = LoggerFactory.getLogger(MilestoneResolver.class);
+
+    private MilestoneResolver() { }
+
+    public static void main(String[] args) throws IOException {
+        final List<JiraAndGithub> mismatchedIssues = findMismatchedIssues();
+        if (mismatchedIssues.isEmpty()) {
+            System.out.println("The JIRA fix version and GitHub milestone are in sync for all DOCK issues");
+        } else {
+            System.out.println("The following issues are mismatched:");
+            mismatchedIssues.forEach(MilestoneResolver::printMismatchedIssue);
+        }
+        mismatchedIssues.forEach(issue -> {
+            final GHIssue gitHubIssue = issue.ghIssue;
+            try {
+                final JiraIssue jiraIssue = Utils.getJiraIssue(issue.jiraIssueId);
+                final GHMilestone ghMilestone = gitHubIssue.getMilestone();
+                final String jiraIssueUrl = getJiraIssueUrl(jiraIssue.key());
+                System.out.println("Processing JIRA issue %s".formatted(jiraIssueUrl));
+                final FixVersion[] fixVersions = jiraIssue.fields().fixVersions();
+                if (fixVersions.length == 0) {
+                    // There is GitHub milestone but no JIRA fix version
+                    updateJiraIssue(jiraIssue.key(), ghMilestone.getTitle());
+                } else if (fixVersions.length == 1 && ghMilestone == null) {
+                    // There's a JIRA fix version, but no GitHub milestone, set the GitHub milestone
+                    updateGitHubMilestone(gitHubIssue.getNumber(), fixVersions[0].name());
+                } else {
+                    System.out.println("The fix version and milestone mismatch must be resolved manually for: %s".formatted(getJiraIssueUrl(issue.jiraIssueId)));
+                }
+            } catch (URISyntaxException | IOException | InterruptedException e) {
+                LOG.error("Error resolving %s".formatted(issue), e);
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private static void updateGitHubMilestone(int gitHubIssue, String jiraFixVersion) {
+        if (Utils.updateGitHubMilestone(gitHubIssue, jiraFixVersion)) {
+            System.out.println("Updated GitHub milestone in %s to %s".formatted(gitHubIssue, jiraFixVersion));
+        } else {
+            System.err.println("Failed to update GitHub milestone in %s".formatted(gitHubIssue));
+        }
+    }
+
+    private static void updateJiraIssue(String jiraIssue, String gitHubMilestone)
+        throws URISyntaxException, IOException, InterruptedException {
+        final String jiraIssueUrl = getJiraIssueUrl(jiraIssue);
+        if (Utils.updateJiraFixVersion(jiraIssue, gitHubMilestone)) {
+            System.out.println("Updated fix version in %s to %s".formatted(jiraIssueUrl,
+                gitHubMilestone));
+        } else {
+            System.err.println("Failed to update fix version in %s".formatted(jiraIssueUrl));
+        }
+    }
+
+    private static void printMismatchedIssue(final MilestoneResolver.JiraAndGithub issue) {
+        final GHIssue ghIssue = issue.ghIssue;
+        final GHMilestone ghMilestone = ghIssue.getMilestone();
+        final String notSet = "<not set>";
+        final String milestone = ghMilestone != null ? ghMilestone.getTitle() : notSet;
+        final String jiraFixVersion = findJiraFixVersion(ghIssue.getBody()).orElse(notSet);
+        System.out.println(
+            "GitHub %s, milestone %s; JIRA %s, fix version %s".formatted(
+                ghIssue.getNumber(),
+                milestone,
+                issue.jiraIssueId,
+                jiraFixVersion));
+    }
+
+    /**
+     * Finds issues where the GitHub milestone does not match the JIRA fix version
+     * @return
+     * @throws IOException
+     */
+    private static List<MilestoneResolver.JiraAndGithub> findMismatchedIssues() throws IOException {
+        final List<GHIssue> openIssues = Utils.findOpenIssues(Utils.getDockstoreRepository());
+        return openIssues.stream()
+            .filter(MilestoneResolver::milestoneAndFixVersionMismatch)
+            .map(ghIssue -> {
+                // If empty, Unito hasn't synced, JIRA issue does not yet exist
+                return Utils.findJiraIssueInBody(ghIssue)
+                    .map(jiraIssue -> new MilestoneResolver.JiraAndGithub(jiraIssue, ghIssue)).orElse(null);
+            })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+    }
+
+    private static boolean milestoneAndFixVersionMismatch(final GHIssue ghIssue) {
+        final GHMilestone milestone = ghIssue.getMilestone();
+        final String body = ghIssue.getBody();
+        final Optional<String> jiraFixVersion = findJiraFixVersion(body);
+        if (jiraFixVersion.isPresent()) {
+            if (milestone == null) {
+                // There's a fix version in JIRA, but none in GitHub
+                return true;
+            }
+            return !milestoneAndFixVersionEqual(jiraFixVersion.get(), milestone.getTitle());
+        } else { // No fix version in JIRA, is there one in GitHub?
+            return milestone != null;
+        }
+    }
+
+    private static String generateJiraIssuesUrl(final List<MilestoneResolver.JiraAndGithub> issues) {
+        return "https://ucsc-cgl.atlassian.net/issues/?jql=project=DOCK AND "
+            + issues.stream().map(issue -> "key=\"" + issue.jiraIssueId() + "\"")
+            .collect(Collectors.joining(" or "));
+    }
+
+    private static String getJiraIssueUrl(String issueNumber) {
+        return "https://ucsc-cgl.atlassian.net/browse/%s".formatted(issueNumber);
+    }
+
+    private static String generateGitHubIssuesUrl(final List<MilestoneResolver.JiraAndGithub> issues) {
+        return "https://github.com/dockstore/dockstore/issues?q="
+            + issues.stream().map(issue -> "" + issue.ghIssue.getNumber())
+            .collect(Collectors.joining("+"));
+    }
+
+    private static boolean milestoneAndFixVersionEqual(String jiraFixVersion, String milestone) {
+        return Utils.JIRA_OPEN_ENDED_RESEARCH_TASKS.equals(jiraFixVersion) && Utils.GITHUB_OPEN_ENDED_RESEARCH_TASKS.equals(milestone)
+            || Objects.equals(jiraFixVersion, milestone);
+    }
+
+    private static Optional<String> findJiraFixVersion(String gitHubIssueBody) {
+        final Matcher matcher = FIX_VERSIONS.matcher(gitHubIssueBody);
+        if (matcher.find()) {
+            return Optional.of(matcher.group(FIX_VERSION_REG_EX_GROUP));
+        }
+        return Optional.empty();
+    }
+
+    record JiraAndGithub(String jiraIssueId, GHIssue ghIssue) { }
+}

--- a/jira_automation/src/main/java/io/dockstore/jira/SprintStart.java
+++ b/jira_automation/src/main/java/io/dockstore/jira/SprintStart.java
@@ -16,7 +16,7 @@ import java.util.Base64;
 public final class SprintStart {
 
     private static final String PROJECT = "SEAB";
-    private static final String BASE_URL = "https://ucsc-cgl.atlassian.net/rest/api/3/";
+    private static final String BASE_URL = Utils.JIRA_REST_BASE_URL;
     private static final String USERS_URL = BASE_URL + "users?maxResults=500";
     private static final String PROJECT_URL = BASE_URL + "project/" + PROJECT;
 

--- a/jira_automation/src/main/java/io/dockstore/jira/Utils.java
+++ b/jira_automation/src/main/java/io/dockstore/jira/Utils.java
@@ -2,28 +2,35 @@ package io.dockstore.jira;
 
 import com.google.gson.Gson;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpRequest.Builder;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.Base64;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHMilestone;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
+import org.kohsuke.github.PagedIterable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class Utils {
 
     public static final String JIRA_REST_BASE_URL = "https://ucsc-cgl.atlassian.net/rest/api/3/";
+    public static final String GITHUB_OPEN_ENDED_RESEARCH_TASKS = "Open ended research tasks";
+    public static final String JIRA_OPEN_ENDED_RESEARCH_TASKS = "Open-ended research tasks";
     private static final Pattern JIRA_ISSUE_IN_GITHUB_BODY = Pattern.compile("((Issue Number)|(friendlyId)): (DOCK-\\d+)");
     private static final int JIRA_ISSUE_GROUP = 4;
 
@@ -31,11 +38,14 @@ public final class Utils {
     private static final String JIRA_USERNAME = "JIRA_USERNAME";
     private static final String JIRA_TOKEN = "JIRA_TOKEN";
 
+    private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
+
+
     private Utils() { }
 
     public static JiraIssue getJiraIssue(String issueId)
         throws URISyntaxException, IOException, InterruptedException {
-        final URI uri = new URI(JIRA_REST_BASE_URL + "issue/" + issueId);
+        final URI uri = getJiraIssueRestUri(issueId);
         final HttpRequest httpRequest = authorizedRequestBuilder()
             .GET()
             .uri(uri)
@@ -43,23 +53,57 @@ public final class Utils {
         final HttpResponse<String> response = HTTP_CLIENT.send(httpRequest, BodyHandlers.ofString());
         final Gson gson = new Gson();
         final String body = response.body();
-        System.out.println("body = " + body);
         final JiraIssue jiraIssue = gson.fromJson(body, JiraIssue.class);
-        System.out.println("jiraIssue = " + jiraIssue);
         return jiraIssue;
     }
 
+    private static URI getJiraIssueRestUri(final String issueId) throws URISyntaxException {
+        return new URI(JIRA_REST_BASE_URL + "issue/" + issueId);
+    }
 
-    public static List<FixVersion> getJiraFixVersions()
+
+    public static boolean updateJiraFixVersion(String issueId, String gitHubMilestone)
         throws URISyntaxException, IOException, InterruptedException {
-        final URI uri = new URI(JIRA_REST_BASE_URL + "project/DOCK/versions");
-        final HttpRequest httpRequest = authorizedRequestBuilder().GET().uri(uri).build();
-        final HttpResponse<String> response =
-            HTTP_CLIENT.send(httpRequest, BodyHandlers.ofString());
-        final Gson gson = new Gson();
-        final FixVersion[] fixVersions = gson.fromJson(response.body(), FixVersion[].class);
-        System.out.println("fixVersions = " + fixVersions);
-        return List.of(fixVersions);
+        final URI uri = getJiraIssueRestUri(issueId);
+        final UpdateJiraIssue updateJiraIssue = new UpdateJiraIssue(new UpdateFields(
+            jiraFixVersionFromGitHubMilestone(gitHubMilestone)));
+        final String json = new Gson().toJson(updateJiraIssue);
+        final HttpRequest httpRequest = authorizedRequestBuilder()
+            .uri(uri)
+            .PUT(BodyPublishers.ofString(json))
+            .header("Content-type", "application/json")
+            .build();
+        final HttpResponse<String> response = HTTP_CLIENT.send(httpRequest, BodyHandlers.ofString());
+        return response.statusCode() < HttpURLConnection.HTTP_MULT_CHOICE;
+    }
+
+    private static FixVersion[] jiraFixVersionFromGitHubMilestone(final String gitHubMilestone) {
+        if (gitHubMilestone == null) {
+            return new FixVersion[0];
+        }
+        return new FixVersion[] {new FixVersion(gitHubMilestoneToJiraVersion(gitHubMilestone))};
+    }
+
+    public static boolean updateGitHubMilestone(int number, String jiraFixVersion)  {
+        try {
+            final GHIssue issue = getDockstoreRepository().getIssue(number);
+            final String ghMilestoneDesc = jiraVersionToGitHubMilestone(jiraFixVersion);
+            final PagedIterable<GHMilestone> ghMilestones =
+                getDockstoreRepository().listMilestones(GHIssueState.ALL);
+            final Optional<GHMilestone> milestone = ghMilestones.toList().stream()
+                .filter(ghMilestone -> ghMilestoneDesc.equals(ghMilestone.getTitle()))
+                .findFirst();
+            if (milestone.isEmpty()) {
+                System.err.println("Could not find GitHub milestone for %s".formatted(jiraFixVersion));
+                return false;
+            }
+            issue.setMilestone(milestone.get());
+        } catch (IOException e) {
+            LOG.error("Error setting milestone on issue %s".formatted(number), e);
+            System.err.println("Error updating milestone for GitHub issue %s".formatted(number));
+            return false;
+        }
+        return true;
     }
 
     public static GHRepository getDockstoreRepository() throws IOException {
@@ -98,6 +142,34 @@ public final class Utils {
         final String jiraToken = System.getenv(JIRA_TOKEN);
         return "Basic %s".formatted(
                 Base64.getEncoder().encodeToString((username + ':' + jiraToken).getBytes()));
+    }
+
+    /**
+     * Converts a GitHub Milestone a JIRA fix version. Generally, the JIRA fix version is the milestone
+     * preceded by Dockstore, e.g., the 1.16 GitHub milestone becomes "Dockstore 1.16" JIRA
+     * fix version. The one exception is "Open ended research tasks" in GitHub becomes
+     * "Open-ended research tasks" (note hyphen).
+     * @param githubMilestone
+     * @return
+     */
+    private static String gitHubMilestoneToJiraVersion(String githubMilestone) {
+        if (githubMilestone == null) {
+            return null;
+        } else if (GITHUB_OPEN_ENDED_RESEARCH_TASKS.equals(githubMilestone)) {
+            return JIRA_OPEN_ENDED_RESEARCH_TASKS;
+        }
+        return "Dockstore %s".formatted(githubMilestone);
+    }
+
+    private static String jiraVersionToGitHubMilestone(String jiraVersion) {
+        final String prefix = "Dockstore ";
+        if (jiraVersion.startsWith(prefix)) {
+            return jiraVersion.substring(prefix.length());
+        } else if (JIRA_OPEN_ENDED_RESEARCH_TASKS.equals(jiraVersion)) {
+            return GITHUB_OPEN_ENDED_RESEARCH_TASKS;
+        }
+        System.err.println("Unexpected jiraVersion: %s".formatted(jiraVersion));
+        return jiraVersion;
     }
 
 

--- a/jira_automation/src/main/java/io/dockstore/jira/Utils.java
+++ b/jira_automation/src/main/java/io/dockstore/jira/Utils.java
@@ -2,15 +2,16 @@ package io.dockstore.jira;
 
 import com.google.gson.Gson;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpRequest.Builder;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.Base64;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -28,6 +29,8 @@ import org.slf4j.LoggerFactory;
 public final class Utils {
 
     public static final String JIRA_REST_BASE_URL = "https://ucsc-cgl.atlassian.net/rest/api/3/";
+    public static final String GITHUB_OPEN_ENDED_RESEARCH_TASKS = "Open ended research tasks";
+    public static final String JIRA_OPEN_ENDED_RESEARCH_TASKS = "Open-ended research tasks";
     private static final Pattern JIRA_ISSUE_IN_GITHUB_BODY = Pattern.compile("((Issue Number)|(friendlyId)): (DOCK-\\d+)");
     private static final int JIRA_ISSUE_GROUP = 4;
 
@@ -35,11 +38,14 @@ public final class Utils {
     private static final String JIRA_USERNAME = "JIRA_USERNAME";
     private static final String JIRA_TOKEN = "JIRA_TOKEN";
 
+    private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
+
+
     private Utils() { }
 
     public static JiraIssue getJiraIssue(String issueId)
         throws URISyntaxException, IOException, InterruptedException {
-        final URI uri = new URI(JIRA_REST_BASE_URL + "issue/" + issueId);
+        final URI uri = getJiraIssueRestUri(issueId);
         final HttpRequest httpRequest = authorizedRequestBuilder()
             .GET()
             .uri(uri)
@@ -47,23 +53,57 @@ public final class Utils {
         final HttpResponse<String> response = HTTP_CLIENT.send(httpRequest, BodyHandlers.ofString());
         final Gson gson = new Gson();
         final String body = response.body();
-        System.out.println("body = " + body);
         final JiraIssue jiraIssue = gson.fromJson(body, JiraIssue.class);
-        System.out.println("jiraIssue = " + jiraIssue);
         return jiraIssue;
     }
 
+    private static URI getJiraIssueRestUri(final String issueId) throws URISyntaxException {
+        return new URI(JIRA_REST_BASE_URL + "issue/" + issueId);
+    }
 
-    public static List<FixVersion> getJiraFixVersions()
+
+    public static boolean updateJiraFixVersion(String issueId, String gitHubMilestone)
         throws URISyntaxException, IOException, InterruptedException {
-        final URI uri = new URI(JIRA_REST_BASE_URL + "project/DOCK/versions");
-        final HttpRequest httpRequest = authorizedRequestBuilder().GET().uri(uri).build();
-        final HttpResponse<String> response =
-            HTTP_CLIENT.send(httpRequest, BodyHandlers.ofString());
-        final Gson gson = new Gson();
-        final FixVersion[] fixVersions = gson.fromJson(response.body(), FixVersion[].class);
-        System.out.println("fixVersions = " + fixVersions);
-        return List.of(fixVersions);
+        final URI uri = getJiraIssueRestUri(issueId);
+        final UpdateJiraIssue updateJiraIssue = new UpdateJiraIssue(new UpdateFields(
+            jiraFixVersionFromGitHubMilestone(gitHubMilestone)));
+        final String json = new Gson().toJson(updateJiraIssue);
+        final HttpRequest httpRequest = authorizedRequestBuilder()
+            .uri(uri)
+            .PUT(BodyPublishers.ofString(json))
+            .header("Content-type", "application/json")
+            .build();
+        final HttpResponse<String> response = HTTP_CLIENT.send(httpRequest, BodyHandlers.ofString());
+        return response.statusCode() < HttpURLConnection.HTTP_MULT_CHOICE;
+    }
+
+    private static FixVersion[] jiraFixVersionFromGitHubMilestone(final String gitHubMilestone) {
+        if (gitHubMilestone == null) {
+            return new FixVersion[0];
+        }
+        return new FixVersion[] {new FixVersion(gitHubMilestoneToJiraVersion(gitHubMilestone))};
+    }
+
+    public static boolean updateGitHubMilestone(int number, String jiraFixVersion)  {
+        try {
+            final GHIssue issue = getDockstoreRepository().getIssue(number);
+            final String ghMilestoneDesc = jiraVersionToGitHubMilestone(jiraFixVersion);
+            final PagedIterable<GHMilestone> ghMilestones =
+                getDockstoreRepository().listMilestones(GHIssueState.ALL);
+            final Optional<GHMilestone> milestone = ghMilestones.toList().stream()
+                .filter(ghMilestone -> ghMilestoneDesc.equals(ghMilestone.getTitle()))
+                .findFirst();
+            if (milestone.isEmpty()) {
+                System.err.println("Could not find GitHub milestone for %s".formatted(jiraFixVersion));
+                return false;
+            }
+            issue.setMilestone(milestone.get());
+        } catch (IOException e) {
+            LOG.error("Error setting milestone on issue %s".formatted(number), e);
+            System.err.println("Error updating milestone for GitHub issue %s".formatted(number));
+            return false;
+        }
+        return true;
     }
 
     public static GHRepository getDockstoreRepository() throws IOException {
@@ -102,6 +142,34 @@ public final class Utils {
         final String jiraToken = System.getenv(JIRA_TOKEN);
         return "Basic %s".formatted(
                 Base64.getEncoder().encodeToString((username + ':' + jiraToken).getBytes()));
+    }
+
+    /**
+     * Converts a GitHub Milestone a JIRA fix version. Generally, the JIRA fix version is the milestone
+     * preceded by Dockstore, e.g., the 1.16 GitHub milestone becomes "Dockstore 1.16" JIRA
+     * fix version. The one exception is "Open ended research tasks" in GitHub becomes
+     * "Open-ended research tasks" (note hyphen).
+     * @param githubMilestone
+     * @return
+     */
+    private static String gitHubMilestoneToJiraVersion(String githubMilestone) {
+        if (githubMilestone == null) {
+            return null;
+        } else if (GITHUB_OPEN_ENDED_RESEARCH_TASKS.equals(githubMilestone)) {
+            return JIRA_OPEN_ENDED_RESEARCH_TASKS;
+        }
+        return "Dockstore %s".formatted(githubMilestone);
+    }
+
+    private static String jiraVersionToGitHubMilestone(String jiraVersion) {
+        final String prefix = "Dockstore ";
+        if (jiraVersion.startsWith(prefix)) {
+            return jiraVersion.substring(prefix.length());
+        } else if (JIRA_OPEN_ENDED_RESEARCH_TASKS.equals(jiraVersion)) {
+            return GITHUB_OPEN_ENDED_RESEARCH_TASKS;
+        }
+        System.err.println("Unexpected jiraVersion: %s".formatted(jiraVersion));
+        return jiraVersion;
     }
 
 

--- a/jira_automation/src/main/java/io/dockstore/jira/Utils.java
+++ b/jira_automation/src/main/java/io/dockstore/jira/Utils.java
@@ -1,6 +1,16 @@
 package io.dockstore.jira;
 
+import com.google.gson.Gson;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.Builder;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Base64;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -13,10 +23,44 @@ import org.kohsuke.github.GitHubBuilder;
 
 public final class Utils {
 
+    public static final String JIRA_REST_BASE_URL = "https://ucsc-cgl.atlassian.net/rest/api/3/";
     private static final Pattern JIRA_ISSUE_IN_GITHUB_BODY = Pattern.compile("((Issue Number)|(friendlyId)): (DOCK-\\d+)");
     private static final int JIRA_ISSUE_GROUP = 4;
 
+    private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+    private static final String JIRA_USERNAME = "JIRA_USERNAME";
+    private static final String JIRA_TOKEN = "JIRA_TOKEN";
+
     private Utils() { }
+
+    public static JiraIssue getJiraIssue(String issueId)
+        throws URISyntaxException, IOException, InterruptedException {
+        final URI uri = new URI(JIRA_REST_BASE_URL + "issue/" + issueId);
+        final HttpRequest httpRequest = authorizedRequestBuilder()
+            .GET()
+            .uri(uri)
+            .build();
+        final HttpResponse<String> response = HTTP_CLIENT.send(httpRequest, BodyHandlers.ofString());
+        final Gson gson = new Gson();
+        final String body = response.body();
+        System.out.println("body = " + body);
+        final JiraIssue jiraIssue = gson.fromJson(body, JiraIssue.class);
+        System.out.println("jiraIssue = " + jiraIssue);
+        return jiraIssue;
+    }
+
+
+    public static List<FixVersion> getJiraFixVersions()
+        throws URISyntaxException, IOException, InterruptedException {
+        final URI uri = new URI(JIRA_REST_BASE_URL + "project/DOCK/versions");
+        final HttpRequest httpRequest = authorizedRequestBuilder().GET().uri(uri).build();
+        final HttpResponse<String> response =
+            HTTP_CLIENT.send(httpRequest, BodyHandlers.ofString());
+        final Gson gson = new Gson();
+        final FixVersion[] fixVersions = gson.fromJson(response.body(), FixVersion[].class);
+        System.out.println("fixVersions = " + fixVersions);
+        return List.of(fixVersions);
+    }
 
     public static GHRepository getDockstoreRepository() throws IOException {
         final GitHub gitHub =
@@ -44,5 +88,17 @@ public final class Utils {
         }
         return Optional.empty();
     }
+
+    private static Builder authorizedRequestBuilder() {
+        return HttpRequest.newBuilder().header("Authorization", getAuthHeaderValue());
+    }
+
+    private static String getAuthHeaderValue() {
+        final String username = System.getenv(JIRA_USERNAME);
+        final String jiraToken = System.getenv(JIRA_TOKEN);
+        return "Basic %s".formatted(
+                Base64.getEncoder().encodeToString((username + ':' + jiraToken).getBytes()));
+    }
+
 
 }

--- a/jira_automation/src/main/java/io/dockstore/jira/Utils.java
+++ b/jira_automation/src/main/java/io/dockstore/jira/Utils.java
@@ -37,6 +37,7 @@ public final class Utils {
     private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
     private static final String JIRA_USERNAME = "JIRA_USERNAME";
     private static final String JIRA_TOKEN = "JIRA_TOKEN";
+    private static final Gson GSON = new Gson();
 
     private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
 
@@ -51,9 +52,8 @@ public final class Utils {
             .uri(uri)
             .build();
         final HttpResponse<String> response = HTTP_CLIENT.send(httpRequest, BodyHandlers.ofString());
-        final Gson gson = new Gson();
         final String body = response.body();
-        final JiraIssue jiraIssue = gson.fromJson(body, JiraIssue.class);
+        final JiraIssue jiraIssue = GSON.fromJson(body, JiraIssue.class);
         return jiraIssue;
     }
 

--- a/jira_automation/src/main/java/io/dockstore/jira/Utils.java
+++ b/jira_automation/src/main/java/io/dockstore/jira/Utils.java
@@ -2,16 +2,15 @@ package io.dockstore.jira;
 
 import com.google.gson.Gson;
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
-import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpRequest.Builder;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.Base64;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -29,8 +28,6 @@ import org.slf4j.LoggerFactory;
 public final class Utils {
 
     public static final String JIRA_REST_BASE_URL = "https://ucsc-cgl.atlassian.net/rest/api/3/";
-    public static final String GITHUB_OPEN_ENDED_RESEARCH_TASKS = "Open ended research tasks";
-    public static final String JIRA_OPEN_ENDED_RESEARCH_TASKS = "Open-ended research tasks";
     private static final Pattern JIRA_ISSUE_IN_GITHUB_BODY = Pattern.compile("((Issue Number)|(friendlyId)): (DOCK-\\d+)");
     private static final int JIRA_ISSUE_GROUP = 4;
 
@@ -38,14 +35,11 @@ public final class Utils {
     private static final String JIRA_USERNAME = "JIRA_USERNAME";
     private static final String JIRA_TOKEN = "JIRA_TOKEN";
 
-    private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
-
-
     private Utils() { }
 
     public static JiraIssue getJiraIssue(String issueId)
         throws URISyntaxException, IOException, InterruptedException {
-        final URI uri = getJiraIssueRestUri(issueId);
+        final URI uri = new URI(JIRA_REST_BASE_URL + "issue/" + issueId);
         final HttpRequest httpRequest = authorizedRequestBuilder()
             .GET()
             .uri(uri)
@@ -53,57 +47,23 @@ public final class Utils {
         final HttpResponse<String> response = HTTP_CLIENT.send(httpRequest, BodyHandlers.ofString());
         final Gson gson = new Gson();
         final String body = response.body();
+        System.out.println("body = " + body);
         final JiraIssue jiraIssue = gson.fromJson(body, JiraIssue.class);
+        System.out.println("jiraIssue = " + jiraIssue);
         return jiraIssue;
     }
 
-    private static URI getJiraIssueRestUri(final String issueId) throws URISyntaxException {
-        return new URI(JIRA_REST_BASE_URL + "issue/" + issueId);
-    }
 
-
-    public static boolean updateJiraFixVersion(String issueId, String gitHubMilestone)
+    public static List<FixVersion> getJiraFixVersions()
         throws URISyntaxException, IOException, InterruptedException {
-        final URI uri = getJiraIssueRestUri(issueId);
-        final UpdateJiraIssue updateJiraIssue = new UpdateJiraIssue(new UpdateFields(
-            jiraFixVersionFromGitHubMilestone(gitHubMilestone)));
-        final String json = new Gson().toJson(updateJiraIssue);
-        final HttpRequest httpRequest = authorizedRequestBuilder()
-            .uri(uri)
-            .PUT(BodyPublishers.ofString(json))
-            .header("Content-type", "application/json")
-            .build();
-        final HttpResponse<String> response = HTTP_CLIENT.send(httpRequest, BodyHandlers.ofString());
-        return response.statusCode() < HttpURLConnection.HTTP_MULT_CHOICE;
-    }
-
-    private static FixVersion[] jiraFixVersionFromGitHubMilestone(final String gitHubMilestone) {
-        if (gitHubMilestone == null) {
-            return new FixVersion[0];
-        }
-        return new FixVersion[] {new FixVersion(gitHubMilestoneToJiraVersion(gitHubMilestone))};
-    }
-
-    public static boolean updateGitHubMilestone(int number, String jiraFixVersion)  {
-        try {
-            final GHIssue issue = getDockstoreRepository().getIssue(number);
-            final String ghMilestoneDesc = jiraVersionToGitHubMilestone(jiraFixVersion);
-            final PagedIterable<GHMilestone> ghMilestones =
-                getDockstoreRepository().listMilestones(GHIssueState.ALL);
-            final Optional<GHMilestone> milestone = ghMilestones.toList().stream()
-                .filter(ghMilestone -> ghMilestoneDesc.equals(ghMilestone.getTitle()))
-                .findFirst();
-            if (milestone.isEmpty()) {
-                System.err.println("Could not find GitHub milestone for %s".formatted(jiraFixVersion));
-                return false;
-            }
-            issue.setMilestone(milestone.get());
-        } catch (IOException e) {
-            LOG.error("Error setting milestone on issue %s".formatted(number), e);
-            System.err.println("Error updating milestone for GitHub issue %s".formatted(number));
-            return false;
-        }
-        return true;
+        final URI uri = new URI(JIRA_REST_BASE_URL + "project/DOCK/versions");
+        final HttpRequest httpRequest = authorizedRequestBuilder().GET().uri(uri).build();
+        final HttpResponse<String> response =
+            HTTP_CLIENT.send(httpRequest, BodyHandlers.ofString());
+        final Gson gson = new Gson();
+        final FixVersion[] fixVersions = gson.fromJson(response.body(), FixVersion[].class);
+        System.out.println("fixVersions = " + fixVersions);
+        return List.of(fixVersions);
     }
 
     public static GHRepository getDockstoreRepository() throws IOException {
@@ -142,34 +102,6 @@ public final class Utils {
         final String jiraToken = System.getenv(JIRA_TOKEN);
         return "Basic %s".formatted(
                 Base64.getEncoder().encodeToString((username + ':' + jiraToken).getBytes()));
-    }
-
-    /**
-     * Converts a GitHub Milestone a JIRA fix version. Generally, the JIRA fix version is the milestone
-     * preceded by Dockstore, e.g., the 1.16 GitHub milestone becomes "Dockstore 1.16" JIRA
-     * fix version. The one exception is "Open ended research tasks" in GitHub becomes
-     * "Open-ended research tasks" (note hyphen).
-     * @param githubMilestone
-     * @return
-     */
-    private static String gitHubMilestoneToJiraVersion(String githubMilestone) {
-        if (githubMilestone == null) {
-            return null;
-        } else if (GITHUB_OPEN_ENDED_RESEARCH_TASKS.equals(githubMilestone)) {
-            return JIRA_OPEN_ENDED_RESEARCH_TASKS;
-        }
-        return "Dockstore %s".formatted(githubMilestone);
-    }
-
-    private static String jiraVersionToGitHubMilestone(String jiraVersion) {
-        final String prefix = "Dockstore ";
-        if (jiraVersion.startsWith(prefix)) {
-            return jiraVersion.substring(prefix.length());
-        } else if (JIRA_OPEN_ENDED_RESEARCH_TASKS.equals(jiraVersion)) {
-            return GITHUB_OPEN_ENDED_RESEARCH_TASKS;
-        }
-        System.err.println("Unexpected jiraVersion: %s".formatted(jiraVersion));
-        return jiraVersion;
     }
 
 


### PR DESCRIPTION
**Description**
Does some syncing of JIRA fix version and GitHub milestone, which Unito does not do.

The syncing problem is because a fix version in JIRA is a multi-value field, whereas the milestone in GitHub is a single-value field.

See JavaDoc in MilestoneResolver.java for further details.

**Review Instructions**
Describe if this ticket needs review and if so, how one may go about it in qa and/or staging environments.
For example, a ticket based on Security Hub, Snyk, or Dependabot may not need review since those services 
will generate new warnings if the issue has not been resolved properly. On the other hand, an infrastructure
ticket that results in visible changes to the end-user will definitely require review. 
Many tickets will likely be between these two extremes, so some judgement may be required.

**Issue**
SEAB-5953

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
