### PR TITLE
Switch build testing to Java 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 parameters:
   java-tag:
     type: string
-    default: "17.0.11"
+    default: "21.0.2"
 orbs:
   build-tools: circleci/build-tools@2.7.0
 executors:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,11 +25,11 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
-          distribution: 'adopt'
+          java-version: 21
+          distribution: 'temurin'
       - name: Build with Maven
         run: ./mvnw -B clean install
       - name: code coverage

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 417 third-party dependencies.
+Lists of 416 third-party dependencies.
      (The Apache Software License, Version 2.0) Adapter: RxJava 2 (com.squareup.retrofit2:adapter-rxjava2:2.9.0 - https://github.com/square/retrofit)
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.13:2.5.32 - https://akka.io/)
@@ -403,7 +403,6 @@ Lists of 417 third-party dependencies.
      (Apache License 2.0) swagger-jaxrs2-servlet-initializer-jakarta (io.swagger.core.v3:swagger-jaxrs2-servlet-initializer-jakarta:2.2.15 - https://github.com/swagger-api/swagger-core/modules/swagger-jaxrs2-servlet-initializer-jakarta)
      (Apache License 2.0) swagger-models (io.swagger:swagger-models:1.6.8 - https://github.com/swagger-api/swagger-core/modules/swagger-models)
      (Apache License 2.0) swagger-models-jakarta (io.swagger.core.v3:swagger-models-jakarta:2.2.15 - https://github.com/swagger-api/swagger-core/modules/swagger-models-jakarta)
-     (MIT License) System Lambda (com.github.stefanbirkner:system-lambda:1.2.1 - https://github.com/stefanbirkner/system-lambda/)
      (MIT License) System Stubs Core (uk.org.webcompere:system-stubs-core:2.0.1 - https://github.com/webcompere/system-stubs/system-stubs-core/)
      (MIT License) System Stubs Jupiter (uk.org.webcompere:system-stubs-jupiter:2.0.1 - https://github.com/webcompere/system-stubs/system-stubs-jupiter/)
      (Apache License 2.0) Throttling Appender (io.dropwizard.logback:logback-throttling-appender:1.4.0 - https://github.com/dropwizard/logback-throttling-appender/)

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -403,7 +403,7 @@ Lists of 417 third-party dependencies.
      (Apache License 2.0) swagger-jaxrs2-servlet-initializer-jakarta (io.swagger.core.v3:swagger-jaxrs2-servlet-initializer-jakarta:2.2.15 - https://github.com/swagger-api/swagger-core/modules/swagger-jaxrs2-servlet-initializer-jakarta)
      (Apache License 2.0) swagger-models (io.swagger:swagger-models:1.6.8 - https://github.com/swagger-api/swagger-core/modules/swagger-models)
      (Apache License 2.0) swagger-models-jakarta (io.swagger.core.v3:swagger-models-jakarta:2.2.15 - https://github.com/swagger-api/swagger-core/modules/swagger-models-jakarta)
-     (Common Public License Version 1.0) System Rules (com.github.stefanbirkner:system-rules:1.16.1 - http://stefanbirkner.github.io/system-rules/)
+     (MIT License) System Lambda (com.github.stefanbirkner:system-lambda:1.2.1 - https://github.com/stefanbirkner/system-lambda/)
      (MIT License) System Stubs Core (uk.org.webcompere:system-stubs-core:2.0.1 - https://github.com/webcompere/system-stubs/system-stubs-core/)
      (MIT License) System Stubs Jupiter (uk.org.webcompere:system-stubs-jupiter:2.0.1 - https://github.com/webcompere/system-stubs/system-stubs-jupiter/)
      (Apache License 2.0) Throttling Appender (io.dropwizard.logback:logback-throttling-appender:1.4.0 - https://github.com/dropwizard/logback-throttling-appender/)

--- a/metricsaggregator/pom.xml
+++ b/metricsaggregator/pom.xml
@@ -181,7 +181,7 @@
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>7.0.5.Final</version>
         </dependency>
@@ -332,7 +332,7 @@
                                 <usedDependency>ch.qos.logback:logback-core</usedDependency>
                                 <usedDependency>com.google.guava:guava</usedDependency>
                                 <usedDependency>jakarta.validation:jakarta.validation-api</usedDependency>
-                                <usedDependency>org.hibernate:hibernate-validator</usedDependency>
+                                <usedDependency>org.hibernate.validator:hibernate-validator</usedDependency>
                                 <usedDependency>org.glassfish:jakarta.el</usedDependency>
                                 <usedDependency>software.amazon.awssdk:auth</usedDependency>
                                 <usedDependency>software.amazon.awssdk:aws-core</usedDependency>

--- a/pom.xml
+++ b/pom.xml
@@ -504,7 +504,7 @@
                                     <version>3.8.5</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>[11.0.11,18.0)</version>
+                                    <version>[17.0.0,22.0)</version>
                                 </requireJavaVersion>
                                 <banDuplicatePomDependencyVersions />
                                 <bannedDependencies>
@@ -677,9 +677,9 @@
             <plugin>
                 <groupId>net.revelc.code</groupId>
                 <artifactId>impsort-maven-plugin</artifactId>
-                <version>1.8.0</version>
+                <version>1.11.0</version>
                 <configuration>
-                    <compliance>17</compliance>
+                    <compliance>21</compliance>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.8</version>
+                    <version>0.8.12</version>
                 </plugin>
                 <plugin>
                     <groupId>com.googlecode.maven-download-plugin</groupId>

--- a/toolbackup/pom.xml
+++ b/toolbackup/pom.xml
@@ -100,9 +100,13 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-lambda</artifactId>
-            <version>1.2.1</version>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -440,6 +444,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
+                <configuration>
+                    <argLine>
+                        -Djava.security.manager=allow
+                        @{argLine}
+                    </argLine>
+                </configuration>
                 <!--
                 <executions>
                     <execution>
@@ -456,6 +466,10 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <skipITs>${skip-toolbackup-ITs}</skipITs>
+                    <argLine>
+                        -Djava.security.manager=allow
+                        @{argLine}
+                    </argLine>
                 </configuration>
                 <executions>
                     <execution>

--- a/toolbackup/pom.xml
+++ b/toolbackup/pom.xml
@@ -101,8 +101,8 @@
 
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>1.16.1</version>
+            <artifactId>system-lambda</artifactId>
+            <version>1.2.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/toolbackup/src/test/java/io/dockstore/toolbackup/client/cli/DirectoryGeneratorTest.java
+++ b/toolbackup/src/test/java/io/dockstore/toolbackup/client/cli/DirectoryGeneratorTest.java
@@ -1,10 +1,10 @@
 package io.dockstore.toolbackup.client.cli;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
 import static io.dockstore.toolbackup.client.cli.Client.CLIENT_ERROR;
 import static io.dockstore.toolbackup.client.cli.constants.TestConstants.DIR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
+import static uk.org.webcompere.systemstubs.SystemStubs.catchSystemExit;
 
 import io.dockstore.toolbackup.client.cli.common.DirCleaner;
 import java.io.File;
@@ -24,17 +24,14 @@ public class DirectoryGeneratorTest {
 
     /**
      * Test that the script exits if the user is attempting to create a directory with the same path as an existing file
-     * @throws Exception
      */
     @Test
     public void createDirExistingFile() throws Exception {
-        int statusCode = catchSystemExit(() -> {
-            File file = new File(DIR + File.separator + "sameName.txt");
-            assumeTrue(file.isFile() || !file.exists());
-            file.createNewFile();
-            DirectoryGenerator.createDir(file.getAbsolutePath());
-        });
-        assertEquals(CLIENT_ERROR, statusCode);
+        File file = new File(DIR + File.separator + "sameName.txt");
+        assumeTrue(file.isFile() || !file.exists());
+        file.createNewFile();
+        int exitCode = catchSystemExit(() -> DirectoryGenerator.createDir(file.getAbsolutePath()));
+        assertEquals(CLIENT_ERROR, exitCode);
     }
 
     @AfterClass

--- a/toolbackup/src/test/java/io/dockstore/toolbackup/client/cli/DirectoryGeneratorTest.java
+++ b/toolbackup/src/test/java/io/dockstore/toolbackup/client/cli/DirectoryGeneratorTest.java
@@ -1,22 +1,21 @@
 package io.dockstore.toolbackup.client.cli;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
+import static io.dockstore.toolbackup.client.cli.Client.CLIENT_ERROR;
 import static io.dockstore.toolbackup.client.cli.constants.TestConstants.DIR;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
 
 import io.dockstore.toolbackup.client.cli.common.DirCleaner;
 import java.io.File;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 
 /**
  * Created by kcao on 25/01/17.
  */
 public class DirectoryGeneratorTest {
-    @Rule
-    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
 
     @BeforeClass
     public static void setUp() {
@@ -29,11 +28,13 @@ public class DirectoryGeneratorTest {
      */
     @Test
     public void createDirExistingFile() throws Exception {
-        exit.expectSystemExit();
-        File file = new File(DIR + File.separator + "sameName.txt");
-        assumeTrue(file.isFile() || !file.exists());
-        file.createNewFile();
-        DirectoryGenerator.createDir(file.getAbsolutePath());
+        int statusCode = catchSystemExit(() -> {
+            File file = new File(DIR + File.separator + "sameName.txt");
+            assumeTrue(file.isFile() || !file.exists());
+            file.createNewFile();
+            DirectoryGenerator.createDir(file.getAbsolutePath());
+        });
+        assertEquals(CLIENT_ERROR, statusCode);
     }
 
     @AfterClass

--- a/tooltester/pom.xml
+++ b/tooltester/pom.xml
@@ -347,6 +347,12 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <argLine>
+                        -Djava.security.manager=allow
+                        @{argLine}
+                    </argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -354,6 +360,10 @@
                 <version>${maven-failsafe.version}</version>
                 <configuration>
                     <skipITs>${skip-tooltester-ITs}</skipITs>
+                    <argLine>
+                        -Djava.security.manager=allow
+                        @{argLine}
+                    </argLine>
                 </configuration>
                 <executions>
                     <execution>

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
@@ -14,7 +14,7 @@ import uk.org.webcompere.systemstubs.stream.SystemErr;
 import uk.org.webcompere.systemstubs.stream.SystemOut;
 
 /**
- * Many tests ignored due to reasons explained in this PR https://github.com/dockstore/dockstore-support/pull/448
+ * Many tests ignored due to reasons explained in this PR <a href="https://github.com/dockstore/dockstore-support/pull/448">...</a>
  */
 
 @ExtendWith(SystemStubsExtension.class)


### PR DESCRIPTION
**Description**
Switch testing to Java 21. Will probably switch jar later as we gain experience
Unblocked with https://github.com/dockstore/dockstore-deploy/pull/794

**Review Instructions**
Builds succeed. Support programs like topic sentence generation, submission, metrics, etc. should just work. Could login to the deployer and run them, display help, etc. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6611

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
