### PR TITLE
Don't submit metrics if there's only the ALL platform

### DIFF
--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/AthenaAggregator.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/AthenaAggregator.java
@@ -84,7 +84,14 @@ public abstract class AthenaAggregator<M extends Metric> {
             LOG.error("Could not execute query for partition {}", partition, e);
             return Map.of();
         }
-        return createMetricByPlatform(queryResultRows);
+
+        Map<String, M> metricByPlatform = createMetricByPlatform(queryResultRows);
+        // Check that metrics exist for actual platforms. May end up with metrics for only 'ALL' if there are no executions of that type
+        // because null platform values are coalesced to 'ALL'.
+        if (metricByPlatform.size() == 1 && metricByPlatform.containsKey(Partner.ALL.name())) {
+            return Map.of();
+        }
+        return metricByPlatform;
     }
 
     public void printQuery(AthenaTablePartition partition) {


### PR DESCRIPTION
**Description**
Follow up to https://github.com/dockstore/dockstore-support/pull/506: discovered while testing in staging that aggregation fails for workflows with only DNAstack validation executions with the following error:

```
14:07:56.348 [ForkJoinPool.commonPool-worker-1] ERROR i.d.m.MetricsAggregatorAthenaClient - Could not post aggregated metrics to Dockstore for tool ID: #workflow/github.com/broadinstitute/gatk-sv/05-ClusterBatch, version v0.19.4-beta, platform(s): [ALL, DNA_STACK]
io.dockstore.openapi.client.ApiException: {"errors":["executionStatusCount.count must not be empty"]}
        at io.dockstore.openapi.client.ApiClient.invokeAPI(ApiClient.java:744)
        at io.dockstore.openapi.client.api.ExtendedGa4GhApi.aggregatedMetricsPut(ExtendedGa4GhApi.java:136)
        at io.dockstore.metricsaggregator.MetricsAggregatorAthenaClient.lambda$aggregateMetrics$0(MetricsAggregatorAthenaClient.java:86)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.ForEachOps$ForEachTask.compute(ForEachOps.java:291)
        at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:754)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
```

We execute the query for run executions even if the workflow has no run executions and this could result in a single empty row with a `ALL` platform because we coalesce null platforms to the `ALL` value. This results in a execution metric that is essentially "empty" and when we try to submit it, it fails with the error above.

The fix in this PR is simple - check that the platform metrics isn't only for the `ALL` platform. We could do a more sophisticated fix in 1.17 (adjust the query, don't run the query if there are no executions of that type, etc.).

**Review Instructions**
See https://github.com/dockstore/dockstore-support/pull/506

**Issue**
[SEAB-6415](https://ucsc-cgl.atlassian.net/browse/SEAB-6415)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[SEAB-6415]: https://ucsc-cgl.atlassian.net/browse/SEAB-6415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ