### PR TITLE
Make deploy_artifacts invokable in GitHub Actions tab

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
 
   machine_integration_test_exec:
     machine: # run the steps with Ubuntu VM
-      image: ubuntu-2204:2024.01.1
+      image: ubuntu-2204:2024.04.4
     environment:
       PGHOST: 127.0.0.1
     resource_class: medium

--- a/.github/workflows/deploy_artifacts.yml
+++ b/.github/workflows/deploy_artifacts.yml
@@ -10,6 +10,9 @@ on:
       - 'release/**'
       - 'hotfix/**'
       - 'dependabot/**'
+  # Allow triggering this in the UI for the 1.16 hotfix releases. Use only for tags.
+  # TODO: remove in 1.18
+  workflow_dispatch:
   
 jobs:
   deploy_artifacts:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Cache

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Cache

--- a/metricsaggregator/pom.xml
+++ b/metricsaggregator/pom.xml
@@ -392,6 +392,12 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <argLine>
+                        -Djava.security.manager=allow
+                        @{argLine}
+                    </argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -399,6 +405,10 @@
                 <version>${maven-failsafe.version}</version>
                 <configuration>
                     <skipITs>${skip-metricsaggregator-ITs}</skipITs>
+                    <argLine>
+                        -Djava.security.manager=allow
+                        @{argLine}
+                    </argLine>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
**Description**
The `deploy_tagged` workflow was removed in https://github.com/dockstore/dockstore-support/pull/510 in favour of using reusable workflows, which prevents us from releasing hotfixes because the hotfix branch does not have this change. I am currently doing the 1.16.1 hotfix and ran into this issue.

This PR adds `workflow_dispatch` to the existing `deploy_artifacts` workflow so that it can be manually invoked when we release 1.16.x hotfixes. This is similar to adding back the old `deploy_tagged` workflow, except it's using the existing `deploy_artifacts` workflow which should make clean up easier in the future.

Note that the `deploy_artifacts` workflow is not invokable in the GitHub UI until it is merged to our default branch, develop. I will create a ticket to remove this workflow_dispatch in 1.18.

**Review Instructions**
Invoke the deploy artifacts workflow for a hotfix tag.

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
