### PR TITLE
java update - cve

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,8 +133,6 @@ jobs:
             - dockstore-support-java-{{ checksum "THIRD-PARTY-LICENSES.txt" }}
             # Find the most recent cache used from any branch
             - dockstore-support-java-
-            # Find the most recent cache used from any branch of the main dockstore repo
-            - dockstore-m2-
       - run:
           name: build
           command: ./mvnw clean install -DskipTests
@@ -159,8 +157,6 @@ jobs:
             - dockstore-support-java-{{ checksum "pom.xml" }}
             # Find the most recent cache used from any branch
             - dockstore-support-java-
-            # Find the most recent cache used from any branch of the main dockstore repo
-            - dockstore-m2-
       - install-git-secrets
       - run:
           name: build-all
@@ -274,8 +270,6 @@ commands:
             - dockstore-support-java-{{ checksum "pom.xml" }}
             # Find the most recent cache used from any branch
             - dockstore-support-java-
-            # Find the most recent cache used from any branch of the main dockstore repo
-            - dockstore-m2-
 
   setup_for_tests:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,8 @@ jobs:
             - dockstore-support-java-{{ checksum "THIRD-PARTY-LICENSES.txt" }}
             # Find the most recent cache used from any branch
             - dockstore-support-java-
+            # Find the most recent cache used from any branch of the main dockstore repo
+            - dockstore-m2-
       - run:
           name: build
           command: ./mvnw clean install -DskipTests
@@ -157,6 +159,8 @@ jobs:
             - dockstore-support-java-{{ checksum "pom.xml" }}
             # Find the most recent cache used from any branch
             - dockstore-support-java-
+            # Find the most recent cache used from any branch of the main dockstore repo
+            - dockstore-m2-
       - install-git-secrets
       - run:
           name: build-all
@@ -270,6 +274,8 @@ commands:
             - dockstore-support-java-{{ checksum "pom.xml" }}
             # Find the most recent cache used from any branch
             - dockstore-support-java-
+            # Find the most recent cache used from any branch of the main dockstore repo
+            - dockstore-m2-
 
   setup_for_tests:
     steps:

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.2_13-jdk-jammy
+FROM eclipse-temurin:21.0.7_6-jdk-jammy
 
 # Update the APT cache
 # Prepare for Java download

--- a/pom.xml
+++ b/pom.xml
@@ -73,36 +73,14 @@
 
     <repositories>
         <repository>
-            <id>artifacts.oicr.on.ca.ca-snapshots</id>
-            <url>https://artifacts.oicr.on.ca/artifactory/collab-snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
             <id>artifacts.oicr.on.ca</id>
             <name>artifacts.oicr.on.ca</name>
             <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
         </repository>
         <repository>
-            <id>apache-releases</id>
-            <name>Apache Releases repository</name>
-            <url>https://repository.apache.org/content/repositories/releases/</url>
-        </repository>
-        <!-- broad -->
-        <repository>
-            <id>artifactory.broadinstitute.org</id>
-            <name>artifactory.broadinstitute.org</name>
-            <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>broad-dependencies.oicr.on.ca</id>
+            <name>broad-dependencies.oicr.on.ca</name>
+            <url>https://artifacts.oicr.on.ca/artifactory/broad-dependencies</url>
         </repository>
     </repositories>
 
@@ -687,7 +665,7 @@
             <plugin>
                 <groupId>net.revelc.code</groupId>
                 <artifactId>impsort-maven-plugin</artifactId>
-                <version>1.11.0</version>
+                <version>1.12.0</version>
                 <configuration>
                     <compliance>21</compliance>
                 </configuration>


### PR DESCRIPTION
**Description**
Misnamed branch, update is actually for Java 
CVE-2024-21147

Some messing with maven versions and artifactories we're using since the build was hanging

**Review Instructions**
Download Docker image (or login to it on qa) and check that java is newer than 21.0.3

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7175

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
