### PR TITLE
update openjdk to update jq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.7_6-jdk-jammy
+FROM eclipse-temurin:21.0.7_6-jdk-noble
 
 # Update the APT cache
 # Prepare for Java download

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 396 third-party dependencies.
+Lists of 401 third-party dependencies.
      (The Apache Software License, Version 2.0) Adapter: RxJava 2 (com.squareup.retrofit2:adapter-rxjava2:2.9.0 - https://github.com/square/retrofit)
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.13:2.5.32 - https://akka.io/)
@@ -315,6 +315,7 @@ Lists of 396 third-party dependencies.
      (Apache License 2.0) Metrics Utility Jakarta Servlets (io.dropwizard.metrics:metrics-jakarta-servlets:4.2.30 - https://metrics.dropwizard.io/metrics-jakarta-servlets)
      (The Apache Software License, Version 2.0) metrics3-statsd (com.readytalk:metrics3-statsd:4.2.0 - no url defined)
      (Apache 2) metrics4-scala (nl.grons:metrics4-scala_2.13:4.2.8 - https://github.com/erikvanoosten/metrics-scala)
+     (Apache Software License, Version 2.0) metricsaggregator (io.dockstore:metricsaggregator:1.17.0-SNAPSHOT - https://github.com/dockstore/dockstore-support)
      (Eclipse Distribution License - v 1.0) MIME streaming extension (org.jvnet.mimepull:mimepull:1.9.15 - https://github.com/eclipse-ee4j/metro-mimepull)
      (Apache 2 License) Moneta Core (org.javamoney.moneta:moneta-core:1.4.2 - http://javamoney.org)
      (MIT) mouse (org.typelevel:mouse_2.13:1.0.11 - https://typelevel.org/mouse)
@@ -392,7 +393,11 @@ Lists of 396 third-party dependencies.
      (Apache License 2.0) Throttling Appender (io.dropwizard.logback:logback-throttling-appender:1.4.2 - https://github.com/dropwizard/logback-throttling-appender/)
      (Apache License, Version 2.0) tomcat-jdbc (org.apache.tomcat:tomcat-jdbc:10.1.34 - https://tomcat.apache.org/)
      (Apache License, Version 2.0) tomcat-juli (org.apache.tomcat:tomcat-juli:10.1.34 - https://tomcat.apache.org/)
+     (GNU General Public License (GPLv3)) toolbackup (io.dockstore:toolbackup:1.17.0-SNAPSHOT - https://github.com/dockstore/dockstore-support)
+     (GNU General Public License (GPLv3)) tooltester (io.dockstore:tooltester:1.17.0-SNAPSHOT - https://github.com/dockstore/dockstore-support)
+     (GNU General Public License (GPLv3)) topicgenerator (io.dockstore:topicgenerator:1.17.0-SNAPSHOT - https://github.com/dockstore/dockstore-support)
      (Eclipse Distribution License - v 1.0) TXW2 Runtime (org.glassfish.jaxb:txw2:3.0.2 - https://eclipse-ee4j.github.io/jaxb-ri/)
+     (GNU General Public License (GPLv3)) utils (io.dockstore:utils:1.17.0-SNAPSHOT - https://github.com/dockstore/dockstore-support)
      (WDL License https://github.com/openwdl/wdl/blob/master/LICENSE) wdl-biscayne (org.broadinstitute:wdl-biscayne_2.13:85 - no url defined)
      (WDL License https://github.com/openwdl/wdl/blob/master/LICENSE) wdl-draft2 (org.broadinstitute:wdl-draft2_2.13:85 - no url defined)
      (WDL License https://github.com/openwdl/wdl/blob/master/LICENSE) wdl-draft3 (org.broadinstitute:wdl-draft3_2.13:85 - no url defined)

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
             <name>broad-dependencies.oicr.on.ca</name>
             <url>https://artifacts.oicr.on.ca/artifactory/broad-dependencies</url>
         </repository>
+        <repository>
+            <id>artifactory.broadinstitute.org</id>
+            <name>artifactory.broadinstitute.org</name>
+            <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
+        </repository>
     </repositories>
 
     <licenses>


### PR DESCRIPTION
**Description**
Update openjdk to resolve CVE-2024-53427 
newer jq version is included with newer ubuntu version
Looking into the link below, the rating of critical/high is misleading. The cli tool is only low since an attacker would need to have console access already

**Review Instructions**
Newer container build and deploy includes newer jq version as per https://ubuntu.com/security/notices/USN-7657-1
Can find this in GitHub actions

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7232

**Security**
None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
