### PR TITLE
SEAB-7450: Increase length of monthly execution count time series

### DIFF
--- a/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/ExecutionStatusAthenaAggregator.java
+++ b/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/helper/ExecutionStatusAthenaAggregator.java
@@ -29,7 +29,7 @@ public class ExecutionStatusAthenaAggregator extends RunExecutionAthenaAggregato
     private final CostAthenaAggregator costAggregator = new CostAthenaAggregator(metricsAggregatorAthenaClient, tableName);
     private final DailyExecutionCountsAthenaAggregator dailyExecutionCountsAggregator = new DailyExecutionCountsAthenaAggregator(metricsAggregatorAthenaClient, tableName, 63, Instant.now()); // Aggregate 2 months + 1 day of daily execution counts
     private final WeeklyExecutionCountsAthenaAggregator weeklyExecutionCountsAggregator = new WeeklyExecutionCountsAthenaAggregator(metricsAggregatorAthenaClient, tableName, 53, Instant.now()); // Aggregate 1 year + 1 week of weekly execution counts
-    private final MonthlyExecutionCountsAthenaAggregator monthlyExecutionCountsAggregator = new MonthlyExecutionCountsAthenaAggregator(metricsAggregatorAthenaClient, tableName, 25, Instant.now()); // Aggregate 2 years + 1 month of monthly execution counts
+    private final MonthlyExecutionCountsAthenaAggregator monthlyExecutionCountsAggregator = new MonthlyExecutionCountsAthenaAggregator(metricsAggregatorAthenaClient, tableName, 61, Instant.now()); // Aggregate 5 years + 1 month of monthly execution counts
     private final HistogramAthenaAggregator executionTimeHistogramAggregator = new HistogramAthenaAggregator(metricsAggregatorAthenaClient, tableName, EXECUTION_TIME_SECONDS_FIELD.cast(Double.class), Sequences.getFriendlyLogRunTimeSequence());
 
     public ExecutionStatusAthenaAggregator(MetricsAggregatorAthenaClient metricsAggregatorAthenaClient, String tableName) {


### PR DESCRIPTION
**Description**
This PR changes the metrics aggregator to increase the number of samples in the monthly execution count time series so that they cover slightly more than five years.  Increased thusly, there's at least enough samples available to create a large time series chart that hits the visual sweet spot, which, to me, given the current layout of the chart, is somewhere in the range of 50-70 samples.  Less samples than 50, the bars get too wide, more samples than 70, the bars get too narrow.

**Review Instructions**
After running the metrics aggregator on qa, check a metrics response and confirm that the monthly times series data has the expected number of samples.  Look at the thumbnail charts in the versions table and search results, and confirm they are not broken.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7450

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
