### PR TITLE
SEAB-7639: Miscellaneaous categorizer tweaks

### DIFF
--- a/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
+++ b/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
@@ -41,6 +41,7 @@ import io.dockstore.utils.IOUtils;
 import io.dockstore.utils.RetrievalUtils;
 import io.dockstore.utils.ai.AIModelFactory;
 import io.dockstore.utils.ai.AIModelType;
+import io.dockstore.utils.ai.LimitExceededException;
 import io.dockstore.utils.ai.LoggingAIModel;
 import io.dockstore.utils.ai.TotalCostAIModel;
 import java.io.IOException;
@@ -229,7 +230,7 @@ public class CategorizerClient {
 
         AIModelType aiModelType = categorizeEntriesCommand.getAiModel();
         double costLimit = categorizeEntriesCommand.getCostLimit();
-        TotalCostAIModel aiModel = new TotalCostAIModel(new LoggingAIModel(AIModelFactory.createModel(aiModelType)), costLimit);
+        TotalCostAIModel aiModel = new TotalCostAIModel(new LoggingAIModel(AIModelFactory.createModel(aiModelType)));
         LOG.info("Categorizing entries using AI model {}", aiModelType.getModelId());
         if (Double.isFinite(costLimit)) {
             LOG.info("Cost limit: ${}", costLimit);
@@ -254,7 +255,10 @@ public class CategorizerClient {
                 try {
                     LOG.info("Categorizing entry {} version {}", trsId, version);
                     // Check if we've exceeded the cost limit, so we can avoid needlessly retrieving the entry data.
-                    aiModel.checkLimit();
+                    if (aiModel.getTotalCost() > costLimit) {
+                        throw new LimitExceededException(
+                            String.format("Cost limit of $%.6f exceeded: total cost is $%.6f", costLimit, aiModel.getTotalCost()));
+                    }
                     // Retrieve data about the entry.
                     final ApiClient apiClient = setupApiClient(dockstoreServerUrl, dockstoreToken);
                     final int maxFieldLength = 200_000;

--- a/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
+++ b/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
@@ -257,7 +257,8 @@ public class CategorizerClient {
                     aiModel.checkLimit();
                     // Retrieve data about the entry.
                     final ApiClient apiClient = setupApiClient(dockstoreServerUrl, dockstoreToken);
-                    final EntryData entryData = retrieveEntryData(apiClient, trsId, version);
+                    final int maxFieldLength = 200_000;
+                    final EntryData entryData = retrieveEntryData(apiClient, trsId, version).limit(maxFieldLength);
                     // For each ontology handler, categorize the entry into the appropriate nodes (categories).
                     for (OntologyHandler handler: ontologyHandlers) {
                         // Determine the "recommended for annotation" nodes that the handler covers.

--- a/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
+++ b/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
@@ -39,6 +39,7 @@ import io.dockstore.utils.CsvWriter;
 import io.dockstore.utils.EntryUtils;
 import io.dockstore.utils.IOUtils;
 import io.dockstore.utils.RetrievalUtils;
+import io.dockstore.utils.ai.AIModel;
 import io.dockstore.utils.ai.AIModelFactory;
 import io.dockstore.utils.ai.AIModelType;
 import io.dockstore.utils.ai.LimitExceededException;
@@ -212,6 +213,20 @@ public class CategorizerClient {
     }
 
     /**
+     * Creates the AI model to use for categorization, optionally wrapping it to log prompts and responses,
+     * and wrapping the result to track total cost and token usage.
+     * @param aiModelType the AI model to create
+     * @param logPrompts whether to log prompts and responses
+     */
+    private TotalCostAIModel createAiModel(AIModelType aiModelType, boolean logPrompts) {
+        AIModel aiModel = AIModelFactory.createModel(aiModelType);
+        if (logPrompts) {
+            aiModel = new LoggingAIModel(aiModel);
+        }
+        return new TotalCostAIModel(aiModel);
+    }
+
+    /**
      * AI-categorizes the entries listed in the input CSV and writes matching ontology node assignments to stdout as CSV.
      * Each entry is processed in a worker thread; per-entry failures are counted and logged but do not abort the run.
      * @param categorizerConfig server URL and API token
@@ -229,9 +244,10 @@ public class CategorizerClient {
         LOG.info("Read {} entries from input file {}", entries.size(), entriesPath);
 
         AIModelType aiModelType = categorizeEntriesCommand.getAiModel();
-        double costLimit = categorizeEntriesCommand.getCostLimit();
-        TotalCostAIModel aiModel = new TotalCostAIModel(new LoggingAIModel(AIModelFactory.createModel(aiModelType)));
+        TotalCostAIModel aiModel = createAiModel(aiModelType, categorizeEntriesCommand.isLogPrompts());
         LOG.info("Categorizing entries using AI model {}", aiModelType.getModelId());
+
+        double costLimit = categorizeEntriesCommand.getCostLimit();
         if (Double.isFinite(costLimit)) {
             LOG.info("Cost limit: ${}", costLimit);
         }

--- a/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
+++ b/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
@@ -254,7 +254,8 @@ public class CategorizerClient {
                 final String version = entry.version();
                 try {
                     LOG.info("Categorizing entry {} version {}", trsId, version);
-                    // Check if we've exceeded the cost limit, so we can avoid needlessly retrieving the entry data.
+                    // Check if we've exceeded the cost limit.
+                    // We check the limit at this point in the code to avoid needlessly retrieving the entry data.
                     if (aiModel.getTotalCost() > costLimit) {
                         throw new LimitExceededException(
                             String.format("Cost limit of $%.6f exceeded: total cost is $%.6f", costLimit, aiModel.getTotalCost()));

--- a/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerCommandLineArgs.java
+++ b/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerCommandLineArgs.java
@@ -44,6 +44,9 @@ public class CategorizerCommandLineArgs {
         @Parameter(names = {"--cost"}, description = "Maximum total AI cost in dollars; the command stops after this limit is exceeded")
         private double costLimit = Double.POSITIVE_INFINITY;
 
+        @Parameter(names = {"--logPrompts"}, description = "Log the AI prompts and responses")
+        private boolean logPrompts = false;
+
         public String getEntriesCsvFilePath() {
             return entriesCsvFilePath;
         }
@@ -62,6 +65,10 @@ public class CategorizerCommandLineArgs {
 
         public double getCostLimit() {
             return costLimit;
+        }
+
+        public boolean isLogPrompts() {
+            return logPrompts;
         }
 
     }

--- a/categorizer/src/main/java/io/dockstore/categorizer/client/cli/EntryData.java
+++ b/categorizer/src/main/java/io/dockstore/categorizer/client/cli/EntryData.java
@@ -1,4 +1,14 @@
 package io.dockstore.categorizer.client.cli;
 
+import org.apache.commons.lang3.StringUtils;
+
 public record EntryData(String entryType, String trsId, String description, String descriptorFileContent) {
+    public EntryData limit(int maxFieldLength) {
+        return new EntryData(
+            StringUtils.truncate(entryType, maxFieldLength),
+            StringUtils.truncate(trsId, maxFieldLength),
+            StringUtils.truncate(description, maxFieldLength),
+            StringUtils.truncate(descriptorFileContent, maxFieldLength)
+        );
+    }
 }

--- a/utils/src/main/java/io/dockstore/utils/ai/TotalCostAIModel.java
+++ b/utils/src/main/java/io/dockstore/utils/ai/TotalCostAIModel.java
@@ -1,35 +1,20 @@
 package io.dockstore.utils.ai;
 
 /**
- * Decorator that accumulates the total cost and token usage across all invocations, optionally
- * enforcing a cost limit.
+ * Decorator that accumulates the total cost and token usage across all invocations.
  */
 public class TotalCostAIModel extends DelegatingAIModel {
 
-    private final double costLimit;
     private double totalCost = 0.0;
     private long totalInputTokens = 0;
     private long totalOutputTokens = 0;
 
     public TotalCostAIModel(AIModel delegate) {
-        this(delegate, Double.POSITIVE_INFINITY);
-    }
-
-    public TotalCostAIModel(AIModel delegate, double costLimit) {
         super(delegate);
-        this.costLimit = costLimit;
-    }
-
-    public synchronized void checkLimit() {
-        if (totalCost > costLimit) {
-            throw new LimitExceededException(
-                String.format("Cost limit of $%.6f exceeded: total cost is $%.6f", costLimit, totalCost));
-        }
     }
 
     @Override
     public Response submitPrompt(Prompt prompt) {
-        checkLimit();
         Response response = super.submitPrompt(prompt);
         synchronized (this) {
             totalCost += response.cost();


### PR DESCRIPTION
**Description**
This PR makes three changes to dockstore-support's categorizer utility:
1. Each attribute of `EntryData` is now truncated to 200,000 characters, to prevent very large descriptor files or descriptions from consuming lots of tokens and/or exceeding the context window.  Currently, in our database, we store notebook files up to 3.5MB in size.
2. The `categorize-entries` command now accepts an optional `--logPrompts` argument, which must be specified to log the contents of each AI prompt.
3. We move the cost limiting logic out of `TotalCostAIModel` and into the categorizer.  This allows us more control over how we implement the behavior that occurs when a limit is reached.  Also, removing the limit check from the `submitPrompt` method avoid the scenario wherein we get partway through a categorization, reach the limit, and abort, thus potentially wasting some prompts and a decent amount of money if we're doing lots of categorizations in parallel.

**Review Instructions**
Exercise the above changes.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7639

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
