### PR TITLE
Add categorizer and ontologies to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,12 @@ RUN rm -fr /tmp/aws
 COPY topicgenerator/target/topicgenerator*[^s].jar /home/topic-generator.jar
 
 COPY metricsaggregator/target/metricsaggregator*[^s].jar /home/metrics-aggregator.jar
+
+COPY categorizer/target/categorizer*[^s].jar /home/categorizer.jar
+
+# Download the generated ontology JSON files from the dockstore/ontology repo
+ARG ONTOLOGY_REF=develop
+RUN mkdir -p /home/ontology
+RUN for f in operation.json topic.json input-format.json input-data.json output-format.json output-data.json; do \
+        curl -sf "https://raw.githubusercontent.com/dockstore/ontology/${ONTOLOGY_REF}/generated/${f}" -o "/home/ontology/${f}"; \
+    done


### PR DESCRIPTION
**Description**
This PR modifies the `Dockerfile` so that the resulting image includes the categorizer jar in the `/home` directory, and the ontology files in the `/home/ontology` directory.  Currently, the code that fetches the ontology files grabs them from the `develop` branch.  After we release the ontology repo, we need to point the code at the release tag.

**Review Instructions**
"Run" the image and check that the files are there.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7639

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
