### PR TITLE
SEAB-7639: Add "cache priming" code to the categorizer

### DIFF
--- a/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
+++ b/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
@@ -285,8 +285,7 @@ public class CategorizerClient {
                     // For each ontology handler, categorize the entry into the appropriate nodes (categories).
                     for (OntologyHandler handler: ontologyHandlers) {
                         // Determine the "recommended for annotation" nodes that the handler covers.
-                        List<Ontology.Node> coveredNodes = handler.coverage(ontology);
-                        List<Ontology.Node> candidateNodes = coveredNodes.stream().filter(Ontology.Node::recommendedForAnnotation).toList();
+                        List<Ontology.Node> candidateNodes = determineCandidateNodes(handler, ontology);
                         // Determine which nodes (categories) match the entry.
                         List<Ontology.Node> matchingNodes = handler.categorize(candidateNodes, entryData, aiModel);
                         // Write the entry and matching node information to the CSV.
@@ -312,6 +311,18 @@ public class CategorizerClient {
     }
 
     /**
+     * Determines the nodes (categories) that a given handler should consider when categorizing an entry.
+     * A node is a candidate if it falls within the handler's coverage of the ontology and is marked as
+     * recommended for annotation.
+     * @param handler the ontology handler whose coverage determines which nodes are considered
+     * @param ontology the full ontology to filter nodes from
+     * @return the list of candidate nodes for the handler to categorize against
+     */
+    private List<Ontology.Node> determineCandidateNodes(OntologyHandler handler, Ontology ontology) {
+        return handler.coverage(ontology).stream().filter(Ontology.Node::recommendedForAnnotation).toList();
+    }
+
+    /**
      * Runs a categorization on dummy data, sequentially and before the real, parallel categorization work begins,
      * so that the AI model's prompt cache (for content such as the per-handler ontology node lists, which is
      * identical across all entries) is already warm once the worker threads start. Without this, several worker
@@ -323,7 +334,7 @@ public class CategorizerClient {
         final EntryData dummyEntryData = new EntryData("workflow", "dummy/dummy-entry", "A dummy entry used to prime the AI model's prompt cache.",
             "This is placeholder descriptor file content used to prime the AI model's prompt cache.");
         for (OntologyHandler handler: ontologyHandlers) {
-            List<Ontology.Node> candidateNodes = handler.coverage(ontology).stream().filter(Ontology.Node::recommendedForAnnotation).toList();
+            List<Ontology.Node> candidateNodes = determineCandidateNodes(handler, ontology);
             try {
                 handler.categorize(candidateNodes, dummyEntryData, aiModel);
             } catch (Exception ex) {

--- a/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
+++ b/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
@@ -262,6 +262,8 @@ public class CategorizerClient {
         );
         checkOverlappingHandlers(ontologyHandlers, ontology);
 
+        primeCache(ontologyHandlers, ontology, aiModel);
+
         final int threadCount = categorizeEntriesCommand.getThreadCount();
         final AtomicInteger numberOfFailures = new AtomicInteger(0);
         try (Writer writer = stdoutWriter(); CsvWriter<Categorization> categorizationsWriter = new CsvWriter<>(writer, Categorization.class)) {
@@ -285,11 +287,9 @@ public class CategorizerClient {
                         // Determine the "recommended for annotation" nodes that the handler covers.
                         List<Ontology.Node> coveredNodes = handler.coverage(ontology);
                         List<Ontology.Node> candidateNodes = coveredNodes.stream().filter(Ontology.Node::recommendedForAnnotation).toList();
-                        if (candidateNodes.isEmpty()) {
-                            continue;
-                        }
-                        // Determine which nodes (categories) match the entry, and write the matching node information to the CSV.
+                        // Determine which nodes (categories) match the entry.
                         List<Ontology.Node> matchingNodes = handler.categorize(candidateNodes, entryData, aiModel);
+                        // Write the entry and matching node information to the CSV.
                         synchronized (categorizationsWriter) {
                             for (Ontology.Node matchingNode: matchingNodes) {
                                 categorizationsWriter.write(new Categorization(entry.trsId(), entry.version(), matchingNode.id(), true));
@@ -309,6 +309,27 @@ public class CategorizerClient {
             exceptionMessage(e, "Unable to create new CSV output file", IO_ERROR);
         }
         LOG.info("Total cost: ${}", aiModel.getTotalCost());
+    }
+
+    /**
+     * Runs a categorization on dummy data, sequentially and before the real, parallel categorization work begins,
+     * so that the AI model's prompt cache (for content such as the per-handler ontology node lists, which is
+     * identical across all entries) is already warm once the worker threads start. Without this, several worker
+     * threads could race to populate the same cache entry on their first request, each paying the "cache miss" cost.
+     * Failures are logged but do not abort the run.
+     */
+    private void primeCache(List<OntologyHandler> ontologyHandlers, Ontology ontology, AIModel aiModel) {
+        LOG.info("Priming the AI model prompt cache");
+        final EntryData dummyEntryData = new EntryData("workflow", "dummy/dummy-entry", "A dummy entry used to prime the AI model's prompt cache.",
+            "This is placeholder descriptor file content used to prime the AI model's prompt cache.");
+        for (OntologyHandler handler: ontologyHandlers) {
+            List<Ontology.Node> candidateNodes = handler.coverage(ontology).stream().filter(Ontology.Node::recommendedForAnnotation).toList();
+            try {
+                handler.categorize(candidateNodes, dummyEntryData, aiModel);
+            } catch (Exception ex) {
+                LOG.error("Unable to prime the AI model prompt cache for handler {}", handler.getName(), ex);
+            }
+        }
     }
 
     /** Submits all runnables to a fixed thread pool and blocks until every task has finished. */

--- a/categorizer/src/main/java/io/dockstore/categorizer/client/cli/ThreeStageOntologyHandler.java
+++ b/categorizer/src/main/java/io/dockstore/categorizer/client/cli/ThreeStageOntologyHandler.java
@@ -67,6 +67,9 @@ public abstract class ThreeStageOntologyHandler implements OntologyHandler {
 
     @Override
     public List<Ontology.Node> categorize(List<Ontology.Node> nodes, EntryData entryData, AIModel aiModel) {
+        if (nodes.isEmpty()) {
+            return List.of();
+        }
         String summary = summarize(entryData, aiModel);
         List<Ontology.Node> matches = classify(nodes, summary, entryData, aiModel);
         return verify(matches, summary, entryData, aiModel);


### PR DESCRIPTION
**Description**
This PR introduces "cache priming" code to the `categorize-entries` command of the categorizer.  Essentially, prior to categorizing actual entries, we run a categorization on a dummy workflow, thus caching many of the prompt prefixes that will be reused later.  This prevents the case where we specify a large thread count, and many categorizations begin in parallel, and simultaneously submit prompts with the same prefix, before it can be cached, thus incurring the non-cached cost.

**Review Instructions**
Confirm that the `categorize-entries` command works properly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7639

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
