### PR TITLE
SEAB-7644: Point at ontology release 1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY metricsaggregator/target/metricsaggregator*[^s].jar /home/metrics-aggregato
 COPY categorizer/target/categorizer*[^s].jar /home/categorizer.jar
 
 # Download the generated ontology JSON files from the dockstore/ontology repo
-ARG ONTOLOGY_REF=develop
+ARG ONTOLOGY_REF=1.0.0
 RUN mkdir -p /home/ontology
 RUN for f in operation.json topic.json input-format.json input-data.json output-format.json output-data.json; do \
         curl -sf "https://raw.githubusercontent.com/dockstore/ontology/${ONTOLOGY_REF}/generated/${f}" -o "/home/ontology/${f}"; \


### PR DESCRIPTION
**Description**
This PR points the dockstore-deploy Dockerfile at the 1.0.0 release of the ontology repo.

**Review Instructions**
Confirm that the Dockerfile references ontology release 1.0.0, and that the resulting image contains the ontology files.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7644

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
