### PR TITLE
SEAB-7639: Improve prompts, periodically output total cost

### DIFF
--- a/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
+++ b/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
@@ -295,6 +295,7 @@ public class CategorizerClient {
                             }
                         }
                     }
+                    LOG.info("Total cost so far: ${}", aiModel.getTotalCost());
                 } catch (Exception ex) {
                     LOG.error("Unable to categorize entry with TRS ID {} and version {}, skipping", trsId, version, ex);
                     numberOfFailures.incrementAndGet();

--- a/categorizer/src/main/java/io/dockstore/categorizer/client/cli/ThreeStageOntologyHandler.java
+++ b/categorizer/src/main/java/io/dockstore/categorizer/client/cli/ThreeStageOntologyHandler.java
@@ -182,7 +182,7 @@ public abstract class ThreeStageOntologyHandler implements OntologyHandler {
     }
 
     protected String saySelectIdsFromTheList() {
-        return "Select %s IDs from the above CSV.  Do not use other IDs.".formatted(rootId.replace("-", " "));
+        return "Only include %s IDs from the above CSV.".formatted(rootId.replace("-", " "));
     }
 
     protected String sayOneIdPerLine() {

--- a/categorizer/src/main/java/io/dockstore/categorizer/client/cli/TopicOntologyHandler.java
+++ b/categorizer/src/main/java/io/dockstore/categorizer/client/cli/TopicOntologyHandler.java
@@ -36,7 +36,7 @@ public class TopicOntologyHandler extends ThreeStageOntologyHandler {
     protected List<String> sayVerifyInstructions(EntryData entryData, Ontology.Node node) {
         String entryType = entryData.entryType();
         return List.of(isGenericNode(node)
-            ? "Does the following topic accurately describe the %s's field of study, area of application, scientific context, or similar?  Only answer 'yes' if the topic strongly relates to the %s's primary purpose.".formatted(entryType, entryType)
+            ? "Does the following topic accurately describe the %s's field of study, area of application, scientific context, or similar?  Only answer 'yes' if it is the %s's primary purpose.".formatted(entryType, entryType)
             : "Does the following topic accurately describe the %s's field of study, area of application, scientific context, or similar?".formatted(entryType)
         );
     }


### PR DESCRIPTION
**Description**
This PR makes small improvements to a couple of the ontology handler prompts.  Specifically, it:
1. Tightens the command that implores the AI to only use IDs from the CSV.
2. Raises the bar for a "generic" topic to be matched.

It also periodically outputs the total cost (so far), which is useful for monitoring a big interactive run.

**Review Instructions**
Confirm that the generated categories generally look right.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7639

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
