### PR TITLE
SEAB-7639: Output sentinel row if entry doesn't match any categories

### DIFF
--- a/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
+++ b/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
@@ -283,6 +283,7 @@ public class CategorizerClient {
                     final int maxFieldLength = 200_000;
                     final EntryData entryData = retrieveEntryData(apiClient, trsId, version).limit(maxFieldLength);
                     // For each ontology handler, categorize the entry into the appropriate nodes (categories).
+                    boolean matchedAnyCategory = false;
                     for (OntologyHandler handler: ontologyHandlers) {
                         // Determine the "recommended for annotation" nodes that the handler covers.
                         List<Ontology.Node> candidateNodes = determineCandidateNodes(handler, ontology);
@@ -292,7 +293,14 @@ public class CategorizerClient {
                         synchronized (categorizationsWriter) {
                             for (Ontology.Node matchingNode: matchingNodes) {
                                 categorizationsWriter.write(new Categorization(entry.trsId(), entry.version(), matchingNode.id(), true));
+                                matchedAnyCategory = true;
                             }
+                        }
+                    }
+                    // If the entry didn't match any category, indicate as much with a sentinel row.
+                    if (!matchedAnyCategory) {
+                        synchronized (categorizationsWriter) {
+                            categorizationsWriter.write(new Categorization(entry.trsId(), entry.version(), "-", true));
                         }
                     }
                 } catch (Exception ex) {


### PR DESCRIPTION
**Description**
This PR changes the categorizer's `categorize-entries` command to output a sentinel row when an entry doesn't match any categories.  The sentinel row contains the nonexistent category id `-`, which the categorizer will try to populate the entry into, fail, and keep going.  When the categorizer attempts to populate said category with the associated entry, it will fail and move on to the next row.

If we don't do this, the `populate-entries` command has no way of knowing that we attempted to categorize the entry, and it will not update entry's "last categorized" date.  

The resulting scenario would be that every night, the categorizer fetches the same small group of uncategorizable entries, tries to categorize them, finds they don't fall into any categories [again], and then fails to update the "last categorized" date, thus setting the stage for the same behavior tomorrow night, and so on, burning precious tokens again and again, for naught.

**Review Instructions**
This is hard to test.  Confirm that the `categorize-entries` command appears to work properly, that's probably good enough.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7639

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
