### PR TITLE
Support all entry types in populate entries

### DIFF
--- a/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
+++ b/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
@@ -34,6 +34,8 @@ import io.dockstore.openapi.client.model.EntryLiteAndVersionName;
 import io.dockstore.openapi.client.model.FileWrapper;
 import io.dockstore.openapi.client.model.Organization;
 import io.dockstore.openapi.client.model.Tool;
+import io.dockstore.openapi.client.model.Workflow;
+import io.dockstore.openapi.client.model.WorkflowSubClass;
 import io.dockstore.utils.CsvReader;
 import io.dockstore.utils.CsvWriter;
 import io.dockstore.utils.EntryUtils;
@@ -78,6 +80,9 @@ import org.slf4j.LoggerFactory;
 public class CategorizerClient {
     private static final Logger LOG = LoggerFactory.getLogger(CategorizerClient.class);
     private static final String AI_ORGANIZATION_NAME = "dockstoreai";
+    private static final String WORKFLOW_TRS_PREFIX = "#workflow/";
+    private static final String SERVICE_TRS_PREFIX = "#service/";
+    private static final String NOTEBOOK_TRS_PREFIX = "#notebook/";
 
     CategorizerClient() {
     }
@@ -437,7 +442,7 @@ public class CategorizerClient {
             try {
                 categoryIdToCollection.put(categoryId, organizationsApi.getCollectionByName(AI_ORGANIZATION_NAME, categoryId));
                 LOG.info("Retrieved category '{}'", categoryId);
-            } catch (ApiException e) {
+            } catch (Exception e) {
                 LOG.error("Unable to retrieve category '{}'", categoryId, e);
             }
         }
@@ -448,9 +453,9 @@ public class CategorizerClient {
         final Map<String, Entry> trsIdToEntry = new HashMap<>();
         for (String trsId: trsIds) {
             try {
-                trsIdToEntry.put(trsId, workflowsApi.getPublishedEntryByPath(trsIdToPath(trsId)));
+                trsIdToEntry.put(trsId, getEntryByTrsID(workflowsApi, trsId));
                 LOG.info("Retrieved entry '{}'", trsId);
-            } catch (ApiException e) {
+            } catch (Exception e) {
                 LOG.error("Unable to retrieve entry '{}'", trsId, e);
             }
         }
@@ -481,7 +486,7 @@ public class CategorizerClient {
             try {
                 organizationsApi.addEntryToCollection(organization.getId(), collection.getId(), entry.getId(), null, "AI", false);
                 LOG.info("Added entry {} to category {}", trsId, categoryId);
-            } catch (ApiException e) {
+            } catch (Exception e) {
                 LOG.error("Unable to add entry {} to category {}", trsId, categoryId, e);
             }
         }
@@ -505,15 +510,52 @@ public class CategorizerClient {
     }
 
     /**
-     * Strips the {@code #workflow/} TRS prefix to produce the plain path expected by
-     * {@link WorkflowsApi#getPublishedEntryByPath}.
+     * Retrieves a published Dockstore entry by its TRS ID. Supports every entry type: workflows, services,
+     * notebooks, apptools, and tools. Workflows, services, notebooks, and apptools are looked up via
+     * {@link WorkflowsApi#getPublishedWorkflowByPath}, which requires (and thus lets us pin down) the specific
+     * subclass of the entry, since these entries can share a path with other subclasses defined in the same
+     * source repository. Tools don't have this ambiguity, so they're looked up via the generic
+     * {@link WorkflowsApi#getPublishedEntryByPath}. In all cases, the retrieved entry's TRS ID is confirmed to
+     * match {@code trsId} before it's returned.
      */
-    private String trsIdToPath(String trsId) {
-        final String workflowPrefix = "#workflow/";
-        if (trsId.startsWith(workflowPrefix)) {
-            return trsId.substring(workflowPrefix.length());
+    private Entry getEntryByTrsID(WorkflowsApi workflowsApi, String trsId) throws ApiException {
+        final Entry entry;
+        if (trsId.startsWith(WORKFLOW_TRS_PREFIX)) {
+            entry = workflowToEntry(workflowsApi.getPublishedWorkflowByPath(
+                trsId.substring(WORKFLOW_TRS_PREFIX.length()), WorkflowSubClass.BIOWORKFLOW, null, null));
+        } else if (trsId.startsWith(SERVICE_TRS_PREFIX)) {
+            entry = workflowToEntry(workflowsApi.getPublishedWorkflowByPath(
+                trsId.substring(SERVICE_TRS_PREFIX.length()), WorkflowSubClass.SERVICE, null, null));
+        } else if (trsId.startsWith(NOTEBOOK_TRS_PREFIX)) {
+            entry = workflowToEntry(workflowsApi.getPublishedWorkflowByPath(
+                trsId.substring(NOTEBOOK_TRS_PREFIX.length()), WorkflowSubClass.NOTEBOOK, null, null));
+        } else {
+            // No TRS prefix: the entry is either a Tool or an AppTool, which share the same (empty) TRS prefix
+            // and so can't be distinguished from the TRS ID alone. Try AppTool first, since (unlike a Tool's
+            // path) an AppTool's path can collide with a workflow/service/notebook defined in the same source
+            // repository; fall back to the generic, unambiguous Tool lookup if it isn't an AppTool.
+            Entry appToolOrTool;
+            try {
+                appToolOrTool = workflowToEntry(workflowsApi.getPublishedWorkflowByPath(trsId, WorkflowSubClass.APPTOOL, null, null));
+            } catch (ApiException e) {
+                appToolOrTool = workflowsApi.getPublishedEntryByPath(trsId);
+            }
+            entry = appToolOrTool;
         }
-        return trsId;
+
+        if (!trsId.equals(entry.getTrsId())) {
+            throw new RuntimeException("Retrieved entry has TRS ID '%s', expected '%s'".formatted(entry.getTrsId(), trsId));
+        }
+        return entry;
+    }
+
+    /**
+     * Converts a {@link Workflow} (or one of its subclasses: BioWorkflow, Service, Notebook, AppTool) to an
+     * {@link Entry}. The two types don't share a common supertype in the generated API client, so only the
+     * fields needed by callers of {@link #getEntryByTrsID}, namely the ID and TRS ID, are copied over.
+     */
+    private Entry workflowToEntry(Workflow workflow) {
+        return new Entry().id(workflow.getId()).trsId(workflow.getTrsId());
     }
 
     /**

--- a/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
+++ b/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
@@ -65,6 +65,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.configuration2.INIConfiguration;
 import org.apache.commons.lang3.StringUtils;
@@ -434,21 +435,16 @@ public class CategorizerClient {
 
         final Organization organization = getAiOrganization(organizationsApi);
 
-        // Map category IDs to the corresponding Dockstore Collections.
-        // We'll use this later to avoid some redundant requests.
-        final List<String> categoryIds = categorizations.stream().map(Categorization::categoryId).distinct().toList();
-        final Map<String, Collection> categoryIdToCollection = new HashMap<>();
-        for (String categoryId: categoryIds) {
-            try {
-                categoryIdToCollection.put(categoryId, organizationsApi.getCollectionByName(AI_ORGANIZATION_NAME, categoryId));
-                LOG.info("Retrieved category '{}'", categoryId);
-            } catch (Exception e) {
-                LOG.error("Unable to retrieve category '{}'", categoryId, e);
-            }
-        }
+        // Retrieve AI-curated categories and map category IDs to the corresponding Dockstore Collections.
+        // We'll use the resulting Map later to avoid some redundant requests.
+        LOG.info("Retrieving AI-curated categories");
+        final List<Collection> collections = getCollectionsFromOrganization(organizationsApi, organization);
+        final Map<String, Collection> categoryIdToCollection = collections.stream()
+            .collect(Collectors.toMap(Collection::getName, Function.identity()));
 
-        // Map entry paths to the corresponding Dockstore Entries.
-        // We'll use this later to avoid some redundant requests.
+        // Map TRS Ids to the corresponding Dockstore Entries.
+        // We'll use the resulting Map later to avoid some redundant requests.
+        LOG.info("Mapping TRS IDs to Entries");
         final List<String> trsIds = categorizations.stream().map(Categorization::trsId).distinct().toList();
         final Map<String, Entry> trsIdToEntry = new HashMap<>();
         for (String trsId: trsIds) {
@@ -627,6 +623,16 @@ public class CategorizerClient {
             return organizationsApi.getOrganizationByName(AI_ORGANIZATION_NAME);
         } catch (ApiException e) {
             exceptionMessage(e, "Unable to retrieve organization '%s'".formatted(AI_ORGANIZATION_NAME), API_ERROR);
+            return null;
+        }
+    }
+
+    /** Retrieves all of the Collections from the specified Organization, aborting on failure. */
+    private List<Collection> getCollectionsFromOrganization(OrganizationsApi organizationsApi, Organization organization) {
+        try {
+            return organizationsApi.getCollectionsFromOrganization(organization.getId(), "");
+        } catch (ApiException e) {
+            exceptionMessage(e, "Unable to retrieve collections from organization '%s'".formatted(organization.getName()), API_ERROR);
             return null;
         }
     }

--- a/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
+++ b/categorizer/src/main/java/io/dockstore/categorizer/client/cli/CategorizerClient.java
@@ -451,8 +451,10 @@ public class CategorizerClient {
             try {
                 trsIdToEntry.put(trsId, getEntryByTrsID(workflowsApi, trsId));
                 LOG.info("Retrieved entry '{}'", trsId);
-            } catch (Exception e) {
-                LOG.error("Unable to retrieve entry '{}'", trsId, e);
+            } catch (ApiException e) {
+                LOG.error("ApiException while retrieving entry '{}'", trsId, e);
+            } catch (RuntimeException e) {
+                LOG.error("Unexpected exception while retrieving entry '{}'", trsId, e);
             }
         }
 
@@ -539,8 +541,10 @@ public class CategorizerClient {
             entry = appToolOrTool;
         }
 
+        // Confirm that the retrieved entry's TRS ID matches the original TRS ID,
+        // to prevent a programming error from triggering an update using information from the wrong entry.
         if (!trsId.equals(entry.getTrsId())) {
-            throw new RuntimeException("Retrieved entry has TRS ID '%s', expected '%s'".formatted(entry.getTrsId(), trsId));
+            throw new TrsIdMismatchException("Retrieved entry has TRS ID '%s', expected '%s'".formatted(entry.getTrsId(), trsId));
         }
         return entry;
     }
@@ -698,6 +702,15 @@ public class CategorizerClient {
             LOG.info("Reindexed {} entries", count);
         } catch (ApiException e) {
             exceptionMessage(e, "Unable to reindex entries", API_ERROR);
+        }
+    }
+
+    /**
+     * Thrown by {@link #getEntryByTrsID} when the retrieved entry's TRS ID does not match the requested TRS ID.
+     */
+    private static class TrsIdMismatchException extends RuntimeException {
+        TrsIdMismatchException(String message) {
+            super(message);
         }
     }
 


### PR DESCRIPTION
**Description**
This PR makes two changes to the categorizer in dockstore-support:
1. We change the code to support the retrieval of all types of entries, so we can convert each TRS ID to a numeric Dockstore entry ID, for use in the collection management endpoints, which accept the numeric IDs.  This change is necessary to upload all of the categorizations via the `populate-entries` command.
2. We modify the categorizer to retrieve all collections for the `dockstoreai` organization in one request, for the purposes of mapping category names (ids) to numeric Dockstore collection IDs.  Previously, we retrieve the categories one-by-one by hitting the endpoint that retrieves a specific collection.  After the categories are populated, the latter approach is ponderously slow, because said endpoint includes information about each member entry, as well as the categories that _it_ is a member of.  

**Review Instructions**
Confirm that the `populate-entries` command works properly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7639

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
