### PR TITLE
probably redundant jaxb

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 400 third-party dependencies.
+Lists of 398 third-party dependencies.
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-slf4j (com.typesafe.akka:akka-slf4j_2.13:2.5.32 - https://akka.io/)
@@ -236,11 +236,9 @@ Lists of 400 third-party dependencies.
      (Apache-2.0) (LGPL-2.1-or-later) Java Native Access (net.java.dev.jna:jna:5.18.1 - https://github.com/java-native-access/jna)
      (The MIT License) Java SemVer (com.github.zafarkhaja:java-semver:0.10.2 - https://github.com/zafarkhaja/jsemver)
      (The Apache Software License, Version 2.0) java-diff-utils (io.github.java-diff-utils:java-diff-utils:4.12 - https://github.com/java-diff-utils/java-diff-utils/java-diff-utils)
-     (CDDL/GPLv2+CE) JavaBeans Activation Framework API jar (javax.activation:javax.activation-api:1.2.0 - http://java.net/all/javax.activation-api/)
      (Apache License 2.0) (LGPL 2.1) (MPL 1.1) Javassist (org.javassist:javassist:3.31.0-GA - https://www.javassist.org/)
      (Eclipse Distribution License - v 1.0) JAXB Core (org.glassfish.jaxb:jaxb-core:4.0.2 - https://eclipse-ee4j.github.io/jaxb-ri/)
      (Eclipse Distribution License - v 1.0) JAXB Runtime (org.glassfish.jaxb:jaxb-runtime:4.0.2 - https://eclipse-ee4j.github.io/jaxb-ri/)
-     (CDDL 1.1) (GPL2 w/ CPE) jaxb-api (javax.xml.bind:jaxb-api:2.3.1 - https://github.com/javaee/jaxb-spec/jaxb-api)
      (Apache License 2.0) JBoss Logging 3 (org.jboss.logging:jboss-logging:3.6.1.Final - http://www.jboss.org)
      (Apache-2.0) JCL 1.2 implemented over SLF4J (org.slf4j:jcl-over-slf4j:2.0.18 - http://www.slf4j.org)
      (Apache License, Version 2.0) jcommander (com.beust:jcommander:1.82 - https://jcommander.org)

--- a/toolbackup/dependency-reduced-pom.xml
+++ b/toolbackup/dependency-reduced-pom.xml
@@ -137,7 +137,6 @@
               <ignoreNonCompile>true</ignoreNonCompile>
               <usedDependencies>
                 <usedDependency>org.glassfish.hk2:hk2-api</usedDependency>
-                <usedDependency>javax.xml.bind:jaxb-api</usedDependency>
               </usedDependencies>
             </configuration>
           </execution>

--- a/toolbackup/pom.xml
+++ b/toolbackup/pom.xml
@@ -227,11 +227,6 @@
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-        </dependency>
     </dependencies>
 
     <build>
@@ -353,7 +348,6 @@
                             <ignoreNonCompile>true</ignoreNonCompile>
                             <usedDependencies>
                                 <usedDependency>org.glassfish.hk2:hk2-api</usedDependency>
-                                <usedDependency>javax.xml.bind:jaxb-api</usedDependency>
                             </usedDependencies>
                         </configuration>
                     </execution>


### PR DESCRIPTION
**Description**
jaxb probably redundant with all the pruning back of the toolbackup module for virus scanning descriptors
Removing jaxb since it should be replaced by jakarta if anything

**Review Instructions**
Build and tests pass

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6047

**Security**
None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` in the project that you have modified (until https://ucsc-cgl.atlassian.net/browse/SEAB-5300 adds multi-module support properly)
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If you are changing dependencies, check with dependabot to ensure you are not introducing new high/critical vulnerabilities
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
